### PR TITLE
HLW-001: project conventions (CLAUDE.md, tickets, branches/PRs, gated deploys)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,90 @@
+# Havasu Lake Weather — working agreement & project notes
+
+Live community weather site for **Havasu Lake, CA** (San Bernardino County — *not*
+Lake Havasu City, AZ) at **havasulakeweather.com**. Fully serverless AWS: an Ambient
+WS-2902D station → CloudFront → Lambda → DynamoDB, a static PWA on S3 + CloudFront,
+plus free public data (NWS, USGS, USBR RISE, Weather Underground).
+
+## How we work (read this first)
+
+1. **Plan before building.** For any new feature or non-trivial change, first gather
+   the info needed (APIs, data, constraints) and **present an implementation plan for
+   approval**. Do not start implementing until Chad says go.
+2. **One ticket per change.** Track work as a lightweight ticket: a markdown file at
+   `docs/issues/HLW-###.md` **and** a matching GitHub issue. (Chad's work projects use
+   the `pm-ticket-creator` agent — that's overkill here; keep this simple.)
+3. **Feature branches + PRs.** Every change lands on a branch named `feat/HLW-###-slug`
+   (or `fix/`, `chore/`) and merges to `main` through a Pull Request that references the
+   ticket. Never commit features straight to `main`. Claude opens the PR; **Chad reviews
+   and merges.**
+4. **Deploys are gated — never deploy without explicit approval.** "Deploy" = anything
+   that changes live infra or the live site: `sam deploy`, `aws s3 sync` to the site
+   bucket, CloudFront invalidations, DynamoDB/schema changes, new scheduled jobs, etc.
+   Building, local mocks, reads, prototypes, and artifacts are fine without asking.
+5. **Git is not a deploy.** Committing and pushing *branches* is expected (messages end
+   with the `Co-Authored-By` trailer). Merging PRs and deploying are Chad's calls.
+
+## Ticket convention (HLW-###)
+
+- **Numbering:** `HLW-001`, `HLW-002`, … zero-padded, sequential. Next number =
+  highest in `docs/issues/` + 1.
+- **File:** `docs/issues/HLW-###-short-slug.md`, from `docs/issues/TEMPLATE.md`.
+- **GitHub issue:** title `HLW-###: <title>`, created via
+  `gh issue create` on `cwoskoski/havasulakeweather`; paste the issue URL back into
+  the md.
+- **Status:** `proposed` → (approved) `in-progress` → `done`. Keep the status line current.
+
+## Feature flow (end to end)
+
+1. Discuss the idea → gather info → **present a plan** (no code yet).
+2. On approval → create `HLW-###.md` + gh issue + a `feat/HLW-###-slug` branch.
+3. Build on the branch — mock-first where a preview helps (see mock params below).
+4. Push the branch and **open a PR** that references the ticket. Chad reviews + merges.
+5. **Ask before deploying.** After merge, on approval → deploy + verify live.
+6. Close: set the ticket to `done`, note what shipped.
+
+## Infra quick-reference (non-secret)
+
+| Thing | Value |
+|---|---|
+| AWS account | `648581682379` |
+| SSO profile | `havasu` |
+| Regions | ingest/data `us-west-2`; site/CDN/ACM `us-east-1` |
+| Ingest+data stack | `havasu-weather-ingest` (`template.yaml`, us-west-2, SAM) |
+| Site stack | `havasu-weather-site` (`site-template.yaml`, us-east-1) |
+| DynamoDB table | `havasu-weather` (pk/sk, on-demand); obs `pk = OBS#<stationId>#YYYY-MM` |
+| Site bucket | `havasu-weather-site-648581682379` |
+| Site CloudFront | `E1FK70K9FGVU2M` → havasulakeweather.com |
+| Lambdas | `havasu-weather-ingest`, `havasu-weather-read`, `havasu-weather-pws-ingest` |
+| Secrets (never commit) | station PASSKEY + WU read key — NoEcho SAM params `AllowedStationKeys`, `WuApiKey` |
+
+## API endpoints (read Lambda, served under CloudFront `/api/*`)
+
+- `/api/current`, `/api/history?hours=N` — our station
+- `/api/forecast`, `/api/alerts` — NWS (free, no key)
+- `/api/compare` — our station vs nearby WU PWS (`KCAHAVAS2`)
+- `/api/water` — lake/river (USGS levels + USBR RISE releases)
+- **Preview/mock:** API `?mock=<scenario>`; page `?demo=1`, `?mockAlerts=`,
+  `?mockForecast=`, `?mockCompare=`, `?mockWater=`
+
+## Deploy commands (run ONLY with approval)
+
+```bash
+# ingest/data stack (us-west-2) — MUST preserve the NoEcho keys or they reset to empty.
+# Retrieve current values from the deployed Lambda env, then pass them back:
+KEY=$(aws lambda get-function-configuration --function-name havasu-weather-read \
+  --region us-west-2 --profile havasu --query 'Environment.Variables.STATION_KEY' --output text)
+sam build && sam deploy --parameter-overrides "AllowedStationKeys=$KEY" "WuApiKey=<current>"
+
+# site (us-east-1)
+aws s3 sync web/ s3://havasu-weather-site-648581682379/ --profile havasu --region us-east-1 --delete
+aws cloudfront create-invalidation --distribution-id E1FK70K9FGVU2M --paths "/*" --profile havasu
+```
+
+## Conventions
+
+- **Node 24** (`nodejs24.x`), ESM modules; AWS SDK v3 ships in the runtime.
+- **PWA:** bump `web/sw.js` `CACHE` (`havasu-wx-vN`) on any `web/` change so installed
+  users pick up the update.
+- **Outdoor data only** — never store indoor readings.
+- **Secrets** are NoEcho SAM params, passed via `--parameter-overrides`, never committed.

--- a/docs/issues/HLW-001-project-conventions.md
+++ b/docs/issues/HLW-001-project-conventions.md
@@ -1,0 +1,37 @@
+# HLW-001: Project conventions — CLAUDE.md, tickets, branches/PRs, gated deploys
+
+- **Status:** in-progress
+- **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/1
+- **Branch:** `feat/HLW-001-project-conventions`
+- **PR:** (opened from this branch)
+- **Created:** 2026-08-12
+
+## Summary
+
+Establish how we work on this repo going forward, so feature work is deliberate,
+reviewable, and safe to ship.
+
+## Motivation / context
+
+Early build moved fast and committed/deployed straight to `main`. Going forward we
+want: a plan before code, a paper trail per change, PR review, and no surprise deploys.
+
+## Plan
+
+- [x] Add `CLAUDE.md` (working agreement + non-secret infra reference + API/mock map).
+- [x] Add `docs/issues/TEMPLATE.md` for the HLW-### ticket format.
+- [x] Add this ticket (HLW-001) and open GitHub issue #1.
+- [x] Do the work on a `feat/` branch and open a PR (this one) instead of committing to `main`.
+
+## Acceptance criteria
+
+- [ ] `CLAUDE.md` merged to `main`.
+- [ ] Convention in use: next feature starts with a plan → ticket + issue → branch → PR.
+- [ ] No deploys happen without explicit approval.
+
+## Notes
+
+- Chad uses the `pm-ticket-creator` agent for work projects; intentionally **not** used
+  here — this lightweight scheme replaces it.
+- Deploy = `sam deploy`, `s3 sync` to the site bucket, CloudFront invalidations, schema
+  or scheduled-job changes. Building / local mocks / prototypes / artifacts are not deploys.

--- a/docs/issues/TEMPLATE.md
+++ b/docs/issues/TEMPLATE.md
@@ -1,0 +1,30 @@
+# HLW-###: <title>
+
+- **Status:** proposed → in-progress → done
+- **GitHub issue:** <url>
+- **Branch:** `feat/HLW-###-slug`
+- **PR:** <url>
+- **Created:** YYYY-MM-DD
+
+## Summary
+
+One or two lines: what we're building and why.
+
+## Motivation / context
+
+Why it matters and who it helps (lake community, searchability, cost, etc.).
+
+## Plan
+
+The approach — present for approval before building.
+
+- [ ] step
+- [ ] step
+
+## Acceptance criteria
+
+- [ ] observable, testable outcome
+
+## Notes
+
+Decisions, data sources, follow-ups, links.


### PR DESCRIPTION
Establishes the working agreement for the repo. **Docs only — no code or infra changes.**

## What's in it
- `CLAUDE.md`: plan-before-implement, lightweight `HLW-###` tickets + GitHub issues, feature branches + PRs, **gated deploys** (nothing ships to live without approval), plus a non-secret infra quick-reference and the API/mock map.
- `docs/issues/TEMPLATE.md` and the first ticket, `HLW-001`.

## Notes
- The `pm-ticket-creator` agent (used on work repos) is intentionally not used here — this is the lighter replacement.
- Review and merge at your discretion; I won't merge or deploy.

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)