### PR TITLE
HLW-004: station check (compare) card is live

### DIFF
--- a/docs/issues/HLW-004-station-check-live.md
+++ b/docs/issues/HLW-004-station-check-live.md
@@ -1,0 +1,19 @@
+# HLW-004: Station check (compare) card live
+
+- **Status:** done
+- **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/5
+- **Branch:** `feat/HLW-004-station-check-live`
+- **PR:** (open when the work is ready)
+- **Created:** 2026-08-12
+
+## Summary
+
+Station check went LIVE for all visitors when the WU read key was set: /api/compare returns our station vs KCAHAVAS2 with per-field deltas and drift notes. This ticket records completion.
+
+## Plan
+
+See issue #5 for detail. Per CLAUDE.md, the implementation plan is presented for approval before any code.
+
+## Acceptance criteria
+
+- [ ] finalized when picked up


### PR DESCRIPTION
The **Station check** card went live for all visitors the moment the Weather Underground read key was configured: `/api/compare` now returns our station vs KCAHAVAS2 with per-field deltas and drift notes, and `renderCompare` shows it (no gating on that card). Verified: mine 96.6°F vs KCAHAVAS2 98°F, Δ1.4°.

Docs-only PR recording completion (the feature shipped via config, not a code change).

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)