### PR TITLE
HLW-012: local dev server for the read API

### DIFF
--- a/dev/server.mjs
+++ b/dev/server.mjs
@@ -1,0 +1,125 @@
+/**
+ * Havasu Lake Weather — local dev server (HLW-012).
+ *
+ * Serves web/ and runs the REAL read handler (ingest/src/read.js) for /api/*,
+ * against real DynamoDB (via the `havasu` SSO profile) and the real NWS/USGS/WU
+ * APIs — so you can test the whole site locally without deploying.
+ *
+ *   npm install        # once, to get the AWS SDK locally
+ *   npm run dev        # -> http://localhost:8788
+ *
+ * Secrets (station key, WU read key) are pulled from the deployed Lambda's
+ * config at startup, so nothing sensitive lives on disk. Override any of them
+ * (incl. AWS_PROFILE / PORT) via the environment or a gitignored .env.local
+ * you source yourself.
+ */
+
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { extname, join, normalize } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const execFileP = promisify(execFile);
+const HERE = fileURLToPath(new URL(".", import.meta.url));
+const ROOT = join(HERE, "..");
+const WEB = join(ROOT, "web");
+
+const PORT = Number(process.env.PORT || 8788);
+const PROFILE = process.env.AWS_PROFILE || "havasu";
+const REGION = process.env.AWS_REGION || "us-west-2";
+
+// Config the read handler reads at import time — set BEFORE importing it.
+process.env.AWS_PROFILE = PROFILE;
+process.env.AWS_REGION = REGION;
+process.env.TABLE_NAME = process.env.TABLE_NAME || "havasu-weather";
+
+// Pull a NoEcho value straight from the deployed Lambda config.
+async function lambdaEnv(name) {
+  const { stdout } = await execFileP("aws", [
+    "lambda", "get-function-configuration",
+    "--function-name", "havasu-weather-read",
+    "--region", REGION, "--profile", PROFILE,
+    "--query", `Environment.Variables.${name}`, "--output", "text",
+  ]);
+  const v = stdout.trim();
+  return v && v !== "None" ? v : "";
+}
+
+async function loadSecrets() {
+  if (!process.env.STATION_KEY) process.env.STATION_KEY = await lambdaEnv("STATION_KEY");
+  if (!process.env.WU_API_KEY) process.env.WU_API_KEY = await lambdaEnv("WU_API_KEY");
+}
+
+const MIME = {
+  ".html": "text/html", ".js": "text/javascript", ".mjs": "text/javascript",
+  ".css": "text/css", ".json": "application/json", ".png": "image/png",
+  ".jpg": "image/jpeg", ".svg": "image/svg+xml", ".ico": "image/x-icon",
+  ".webmanifest": "application/manifest+json", ".xml": "application/xml", ".txt": "text/plain",
+};
+
+function toEvent(req, url) {
+  return {
+    rawPath: url.pathname,
+    requestContext: { http: { method: req.method, path: url.pathname } },
+    queryStringParameters: Object.fromEntries(url.searchParams),
+  };
+}
+
+async function serveStatic(res, pathname) {
+  let rel = decodeURIComponent(pathname);
+  if (rel === "/") rel = "/index.html";
+  const safe = normalize(rel).replace(/^(\.\.[/\\])+/, "");
+  const file = join(WEB, safe);
+  if (!file.startsWith(WEB)) { res.writeHead(403).end("forbidden"); return; }
+  try {
+    const buf = await readFile(file);
+    res.writeHead(200, { "content-type": MIME[extname(file)] || "application/octet-stream", "cache-control": "no-store" });
+    res.end(buf);
+  } catch {
+    try {
+      const buf = await readFile(join(WEB, "index.html"));
+      res.writeHead(200, { "content-type": "text/html", "cache-control": "no-store" });
+      res.end(buf);
+    } catch { res.writeHead(404).end("not found"); }
+  }
+}
+
+async function main() {
+  await loadSecrets();
+  console.log(`[dev] TABLE_NAME=${process.env.TABLE_NAME}  profile=${PROFILE}  region=${REGION}`);
+  console.log(`[dev] STATION_KEY ${process.env.STATION_KEY ? "loaded" : "MISSING"} | WU_API_KEY ${process.env.WU_API_KEY ? "loaded" : "not set"}`);
+
+  // Import AFTER env is set (read.js and its modules read process.env at load).
+  const { handler } = await import("../ingest/src/read.js");
+
+  const server = createServer(async (req, res) => {
+    const url = new URL(req.url, `http://localhost:${PORT}`);
+    if (url.pathname.startsWith("/api/")) {
+      try {
+        const out = await handler(toEvent(req, url));
+        const headers = { ...(out.headers || {}), "access-control-allow-origin": "*" };
+        res.writeHead(out.statusCode || 200, headers);
+        res.end(out.body || "");
+      } catch (e) {
+        console.error("[dev] handler error:", e);
+        res.writeHead(500, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "dev-handler", detail: String(e?.message || e) }));
+      }
+      return;
+    }
+    await serveStatic(res, url.pathname);
+  });
+
+  server.listen(PORT, () => {
+    console.log(`\n  ▸ Havasu dev server → http://localhost:${PORT}`);
+    console.log(`     full site + live /api/* (real DynamoDB + NWS/USGS/WU). Try:`);
+    console.log(`       http://localhost:${PORT}/`);
+    console.log(`       http://localhost:${PORT}/?demo=1`);
+    console.log(`       http://localhost:${PORT}/api/current`);
+    console.log(`       http://localhost:${PORT}/api/water?mock=high-release\n`);
+  });
+}
+
+main().catch((e) => { console.error("[dev] failed to start:", e); process.exit(1); });

--- a/docs/issues/HLW-012-local-dev-server.md
+++ b/docs/issues/HLW-012-local-dev-server.md
@@ -1,9 +1,9 @@
 # HLW-012: Local dev — run the read API locally against real data
 
-- **Status:** proposed
+- **Status:** in-progress (built + verified locally)
 - **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/14
 - **Branch:** `feat/HLW-012-local-dev-server`
-- **PR:** (open when the work is ready)
+- **PR:** (opened from this branch)
 - **Created:** 2026-08-12
 
 ## Summary
@@ -37,13 +37,25 @@ it. A local runner tightens the loop and reduces deploys — which pairs well wi
 
 ## Plan
 
-- [ ] Confirm approach (Node wrapper vs SAM local; `.env.local` vs fetch-at-startup).
-- [ ] Implement `dev/server.mjs` + `npm run dev`.
-- [ ] Frontend localhost API base → same-origin local server.
-- [ ] `.gitignore` the env file; document the required vars in README/CLAUDE.md.
+- [x] Approach: Node wrapper (no Docker) + keys fetched from the deployed Lambda at startup.
+- [x] Implement `dev/server.mjs` + `npm run dev` (root `package.json`, `@aws-sdk` dev deps).
+- [x] Frontend localhost API base → same-origin (`file://` still uses the deployed URL).
+- [x] Secrets: fetched at startup (nothing on disk); `.env`/`.env.local` already gitignored.
+
+## How to run
+
+```bash
+aws sso login --profile havasu   # DynamoDB-backed endpoints need a live SSO session
+npm install                      # once — installs @aws-sdk locally
+npm run dev                      # -> http://localhost:8788
+```
 
 ## Acceptance criteria
 
-- [ ] `npm run dev` serves the site + all `/api/*` locally against real data.
-- [ ] Mock params (`?demo=1`, `?mockWater=`, …) work locally.
-- [ ] No secrets committed.
+- [x] `npm run dev` serves the site + `/api/*` locally. NWS endpoints (`/api/forecast`,
+      `/api/alerts`) and all `?mock=` states return real/mock data with no creds.
+- [x] Mock params (`?demo=1`, `?mockWater=`, …) work locally.
+- [x] No secrets committed (keys pulled from the Lambda config at runtime).
+- [ ] DynamoDB-backed endpoints (`/api/current`, `/api/history`, live `/api/compare` &
+      `/api/water`) verified — needs a fresh `aws sso login` (token was expired during the
+      first test; not a code issue).

--- a/docs/issues/HLW-012-local-dev-server.md
+++ b/docs/issues/HLW-012-local-dev-server.md
@@ -1,0 +1,49 @@
+# HLW-012: Local dev — run the read API locally against real data
+
+- **Status:** proposed
+- **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/14
+- **Branch:** `feat/HLW-012-local-dev-server`
+- **PR:** (open when the work is ready)
+- **Created:** 2026-08-12
+
+## Summary
+
+Run the read API locally so we can test the whole site (real conditions, forecast,
+alerts, compare, water, and all the `?mock=` states) without deploying.
+
+## Motivation
+
+Right now every change to the API means `sam deploy` + CloudFront invalidation to see
+it. A local runner tightens the loop and reduces deploys — which pairs well with the
+"deploys are gated" rule.
+
+## Proposed approach (Docker-free)
+
+- `dev/server.mjs`: a small Node http server that
+  - serves `web/` static files, and
+  - for `/api/*`, builds a Function-URL-style event (`rawPath`, `requestContext.http.method`,
+    `queryStringParameters`) and calls the `handler` exported from `ingest/src/read.js`.
+- Uses the `havasu` SSO profile for DynamoDB and hits the real external APIs (NWS / USGS / WU).
+- Secrets from a **gitignored `.env.local`** (TABLE_NAME, STATION_KEY, WU_API_KEY, NWS_*,
+  RISE_*) — or fetched from the deployed Lambda config at startup so nothing lives on disk.
+- Point the frontend's localhost API base at the local server (same-origin) so both mock
+  params and real endpoints resolve locally.
+- `npm run dev` → `http://localhost:PORT` with the full PWA + live `/api/*`.
+
+## Alternatives considered
+
+- `sam local start-api` — official, but needs Docker and is heavier/slower for a single handler.
+- DynamoDB Local — offline testing without real data; overkill for now.
+
+## Plan
+
+- [ ] Confirm approach (Node wrapper vs SAM local; `.env.local` vs fetch-at-startup).
+- [ ] Implement `dev/server.mjs` + `npm run dev`.
+- [ ] Frontend localhost API base → same-origin local server.
+- [ ] `.gitignore` the env file; document the required vars in README/CLAUDE.md.
+
+## Acceptance criteria
+
+- [ ] `npm run dev` serves the site + all `/api/*` locally against real data.
+- [ ] Mock params (`?demo=1`, `?mockWater=`, …) work locally.
+- [ ] No secrets committed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,476 @@
+{
+  "name": "havasu-lake-weather",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "havasu-lake-weather",
+      "version": "0.1.0",
+      "dependencies": {
+        "@aws-sdk/client-dynamodb": "^3",
+        "@aws-sdk/lib-dynamodb": "^3"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb": {
+      "version": "3.1109.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1109.0.tgz",
+      "integrity": "sha512-X01HO3zd6gG1ug6EAfEYxH4VsMiOFWYlmL6/eW0zmbwOsOMlD55MzXTjDfZJKtB/HUZ8mWau+dgnolLZlRZ59w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/credential-provider-node": "^3.972.79",
+        "@aws-sdk/dynamodb-codec": "^3.973.42",
+        "@aws-sdk/middleware-endpoint-discovery": "^3.972.28",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.977.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.7.tgz",
+      "integrity": "sha512-I88Iov89NVmjSmJLKSv7Cn9M2J+a2942OkA8nZCbz+sl4ZeY4zEOcoLOrbt1GRfQ8zEQKnjAJdXixA3J/p1fDQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.3",
+        "@aws-sdk/xml-builder": "^3.972.38",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.31.1",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.68",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.68.tgz",
+      "integrity": "sha512-2a20A/IdNOwUvaDq91iqqS7BA0XlNMfW3iLGZGZLJv0EbUqhSxB0PIx4rQQqssvWj1uXImb3/UCCdHz/+1dOiA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.70.tgz",
+      "integrity": "sha512-0yRem2Fs52r/Nn6UAqIlpjexfaYj8ziEozOe9tamtAVT/5bzFLKx8O2r7MaRqgS3hGKHIa1Jij9nKHSsNnb04A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.13.tgz",
+      "integrity": "sha512-2M39DE02XpYYaSWYk/4AsImXYUU/1L2xmTMLUpMMWq7DfLv191/vCRy3baKtdr45AkJQyVgSjmuVOLm15SwrRQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/credential-provider-env": "^3.972.68",
+        "@aws-sdk/credential-provider-http": "^3.972.70",
+        "@aws-sdk/credential-provider-login": "^3.972.75",
+        "@aws-sdk/credential-provider-process": "^3.972.68",
+        "@aws-sdk/credential-provider-sso": "^3.973.12",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.74",
+        "@aws-sdk/nested-clients": "^3.997.42",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.75",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.75.tgz",
+      "integrity": "sha512-jaTESuJlQsoUZ44f/i2puyPt8VlF/dMMJ9HM3cStYtk7eKX4N9UWi83OLixUkoOJH3BwWlPLCq9YIK9nfWhVBg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/nested-clients": "^3.997.42",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.79",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.79.tgz",
+      "integrity": "sha512-RIw5dof1EHkWubrZzPC941CDtnFG1iAXsxbFgLkhdYZXHc4icU13c/uxSMI0J5eUx9bxa7LjfpdjfClBB1QsDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.68",
+        "@aws-sdk/credential-provider-http": "^3.972.70",
+        "@aws-sdk/credential-provider-ini": "^3.973.13",
+        "@aws-sdk/credential-provider-process": "^3.972.68",
+        "@aws-sdk/credential-provider-sso": "^3.973.12",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.74",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.68",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.68.tgz",
+      "integrity": "sha512-nLP3Pda2MQTFJ25hKBMmUuB9Uv+bTZQNlufbeCwklP549Vwnkd8bRLJoCKp5k6xjmdyptrPrOfGOhN0mKuca8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.12.tgz",
+      "integrity": "sha512-EmgyyHn+f9WCcelp3L/vci+LGbX8GigWaVphRArjVo5Pktkr9YnLy/mQ6VDkDyBD72dtfRNTgHmD2ts4rTDXKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/nested-clients": "^3.997.42",
+        "@aws-sdk/token-providers": "3.1108.0",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.74",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.74.tgz",
+      "integrity": "sha512-0YfczxGXF3RjGj8z7QG/Ho2HnLGKDHfPSHiTs47UU1U/+mmwISDN+rvGKt2zh+3FX8NdT4xd95LGBGyhQw2dgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/nested-clients": "^3.997.42",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/dynamodb-codec": {
+      "version": "3.973.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.42.tgz",
+      "integrity": "sha512-EJjm82YDsWjN991merbDHEprA1s8OYPRtPYaMD57MvilZeCJ4lMAld/gZGFpVN6d1dmYoh4DKTFlWJVfmfMhcg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/endpoint-cache": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.10.tgz",
+      "integrity": "sha512-xL5sogJajtyGU8p/pA2e8P6dQqs0P6wj2FtBNcZ5VxyBovpoxghKi9hPEkjx+THZijgGW9fOP9EsHDcraSxF8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mnemonist": "0.38.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/lib-dynamodb": {
+      "version": "3.1109.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.1109.0.tgz",
+      "integrity": "sha512-xP+iKnjU1eYT3+RqjXum5bz9qLs0SKpcEjXzb11ck7U7l4M0Cv4w1tGCUF7kdvmPc+sR2jSlT6fwDkKuB6+svQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/util-dynamodb": "^3.996.8",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1109.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery": {
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.28.tgz",
+      "integrity": "sha512-T4F2dZRK80PyigacWVH2Garx6x3oH24tfOZxsv8zLqha+0K0zBS4GvbnFTgHTVjAdJGAYisxQHD/TNDJh+Up/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/endpoint-cache": "^3.972.10",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.42.tgz",
+      "integrity": "sha512-XWRyon2MTHXD/zMoo0Mbge6Vwf+iE0qQaM/RyGO6NfZ9WukCFiQL27nQVZjYy2JwSIg+iXZxKOX95OBXqlSM4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.44",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.44.tgz",
+      "integrity": "sha512-ZSfQ35Qn4MhSY+A0Whyr+KBx+wJKZUyBsOrjB2pSHOafRzbFe47T8XcXM8hZqUAC69qnqIy0C9ArxTuud0CC2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1108.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1108.0.tgz",
+      "integrity": "sha512-rI80zxDxGJ6904eC/YbjkdjY6JdaZvQ01kOmrMvw7cFQGIHo27fhnIVbMSVDS4T6foQImjxYSRoOu/uSJscXDw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/nested-clients": "^3.997.42",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.3.tgz",
+      "integrity": "sha512-ECAqfpNsef+7MO8qtR0h9KcFIBAygaE7Cm6UOiQl+ft+uVap+1G7bNEjs4mdJE2OnA4m6k7i8peH8uGIAsOMGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-dynamodb": {
+      "version": "3.996.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.996.8.tgz",
+      "integrity": "sha512-zg9Scj7J5MCQS4XeEkvKwPN6Crw3oYjFBICxfPpcrIurEKhckL1o/Co8cNKC2WxsYwKmaywFTB8cxpmJqSUx5Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1108.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.38.tgz",
+      "integrity": "sha512-grf7mzfVxBS5AlsuTvBN7uDpzqohFww9fRPCO+EBSUdvtsYMcPSKdz54h/7XiscqNcUM1Ae1MF7JLHmiYYuzbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.32.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.32.0.tgz",
+      "integrity": "sha512-NAiCSC78fzbNIEWoheoF74Ob5ZorLijCHpMY26Fqvqg/+9LuyIqMfHDg2p8Yk1rqOyowtiL3y7WX0AW+teL6zw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.0.tgz",
+      "integrity": "sha512-2jsPi+7Zv2hSzD9IXR9D7DTqSn7mv4XalzRm+bESh53jiaUS3NKEUbpQFTJP0HhQy9qzZvluxQ3yS24zdRrqsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.32.0",
+        "@smithy/types": "^4.17.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.7.0.tgz",
+      "integrity": "sha512-W/exA8T0LEzCQtJ02w4IzaEQPIspgarqZprb7W8FwnYiDowgCrjl2fTQ6FvuSSUnJORuepBF81abmBJwqh+0XQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.32.0",
+        "@smithy/types": "^4.17.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.10.0.tgz",
+      "integrity": "sha512-nrh7VxqzPQS/ip1hS293aI/OAWDWARQvjUxCfuKhyrfHa2gTdk28066RNeWLI1uuoHXaKAkOF8IcSAHuOp0+SA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.32.0",
+        "@smithy/types": "^4.17.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.0.tgz",
+      "integrity": "sha512-hCynhm22wMJ8wTF9crcwu8mxggtUrSLLJgDcGUvYFBqpofxycYJCGKOMYg4xtPPFtgNiDJSYmhsWLTrcU/g59Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.32.0",
+        "@smithy/types": "^4.17.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.0.tgz",
+      "integrity": "sha512-Aw4joiM0ZdErpo39lCj8phT2lxoiKZV+KZzBxnnQhWVtU2Is/WffQSL04uUWRcXUse9Ln8vXZK6V/FwqRVnQpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/mnemonist": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "license": "MIT",
+      "dependencies": {
+        "obliterator": "^1.6.1"
+      }
+    },
+    "node_modules/obliterator": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "havasu-lake-weather",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Havasu Lake Weather — local dev runner for the read API + static site",
+  "scripts": {
+    "dev": "node dev/server.mjs"
+  },
+  "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3",
+    "@aws-sdk/lib-dynamodb": "^3"
+  }
+}

--- a/web/index.html
+++ b/web/index.html
@@ -561,7 +561,9 @@
 
 <script>
 (function(){
-  var API=(location.hostname==="localhost"||location.hostname==="127.0.0.1"||location.protocol==="file:")
+  // Same-origin by default (prod CloudFront /api/*, and the local dev server on localhost).
+  // Only a file:// open (no server) falls back to the deployed Lambda URL.
+  var API=(location.protocol==="file:")
     ? "https://ptbiuyiuoswsxhylotz4jrufjy0abmgd.lambda-url.us-west-2.on.aws" : "";
   var $=function(id){return document.getElementById(id);};
   function set(id,val){var el=$(id);if(!el)return;var s=String(val);if(el.textContent!==s){el.textContent=s;el.classList.remove("flash");void el.offsetWidth;el.classList.add("flash");}}


### PR DESCRIPTION
Run the whole site locally against real data — no deploy needed.

## What
- `dev/server.mjs` — a Docker-free Node server that serves `web/` and runs the **real** `ingest/src/read.js` handler for `/api/*`, hitting real DynamoDB (via the `havasu` SSO profile) and the real NWS/USGS/WU APIs.
- Secrets (station key, WU key) are **fetched from the deployed Lambda config at startup** — nothing sensitive on disk.
- Root `package.json` with `npm run dev`; `@aws-sdk` as a dev dependency.
- Frontend API base is now **same-origin by default** (prod CloudFront `/api/*` *and* the local dev server); only a `file://` open falls back to the deployed Lambda URL. **Prod behavior is unchanged.**

## Verified locally
- Static site (`GET /` 200), `/api/forecast` + `/api/alerts` = real NWS (caught the live Flash Flood Warning), all `?mock=` states.
- DynamoDB-backed endpoints need a fresh `aws sso login --profile havasu` (token was expired mid-test — environmental, not a code issue).

## Run
```
aws sso login --profile havasu
npm install
npm run dev   # http://localhost:8788
```

No deploy required for this (dev-only); the `web/index.html` API-base tweak is a prod no-op and rides along with the next release.

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)