### PR TITLE
HLW-011: normalize "raining now" (rate-based + debounce)

### DIFF
--- a/docs/issues/HLW-011-normalize-raining.md
+++ b/docs/issues/HLW-011-normalize-raining.md
@@ -1,0 +1,53 @@
+# HLW-011: Normalize "raining now" (rate-based + debounce)
+
+- **Status:** proposed
+- **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/13
+- **Branch:** `feat/HLW-011-normalize-raining`
+- **PR:** (open when the work is ready)
+- **Created:** 2026-08-12
+
+## Summary
+
+The "raining now" section flaps Dry↔Raining every minute during steady rain.
+Switch the signal from the tipping-bucket delta to the station's rain-rate field
+(`hourlyrainin`) with a short debounce so it reads reliably.
+
+## Analysis (from live data during a monsoon)
+
+- Current logic (`handler.js:106`): `rainingNow = reading.totalrainin > mark.totalrainin`
+  — i.e. "did the all-time counter increase since the previous single reading."
+- `totalrainin` is a **tipping bucket**: it only jumps in 0.01″ steps when the bucket
+  tips (every 1–8 min). Between tips it's flat → reads **Dry** even in a downpour.
+- Live window 22:43–22:59 UTC: `rainingNow=True` on only **5/90** readings, **8 flips**.
+  Newest reading `hourlyrainin=0.047` (drizzling) but `rainingNow=False` → site said Dry.
+- Station does **not** send `rainratein` (0/90). But `hourlyrainin` acts as a **rain
+  rate**: peaks 0.236 in/hr, exceeds daily/total (so it's a rate, not accumulation),
+  and is exactly 0.000 when dry — a clean, non-flapping signal.
+
+```
+dry:    22:13–22:42  hourlyrainin = 0.000
+onset:  22:43 0.047 → 22:44 0.118 → 22:46 0.165 → 22:48 0.236  (rising)
+easing: 22:56 0.165 → 22:57 0.118 → 22:59 0.047               (decaying)
+```
+
+## Plan
+
+- [ ] Base "raining now" on `hourlyrainin > 0` (rate) instead of the tip delta.
+- [ ] Debounce: stay Raining until the rate has read 0 for ~10–15 min; only then Dry.
+- [ ] Compute in the read API (latest reading + a small recent-window query for the
+      debounce), decoupling from the fragile in-memory watermark.
+- [ ] `lastRainAt` = last time the rate was > 0.
+- [ ] Verify against the recorded flapping window (should read steady Raining through it).
+
+## Acceptance criteria
+
+- [ ] During continuous rain the section stays "Raining" (no minute-to-minute flips).
+- [ ] Flips to "Dry" only after the debounce window with no rain rate.
+- [ ] Backed by a replay of the 22:43–22:59 data (0 spurious Dry readings).
+
+## Notes
+
+- Secondary (separate ticket later): a ~5-min data gap (22:50→22:56) and a post-interval
+  seconds shift (:45→:01) — minor station/ingest hiccup, not part of this fix.
+- Decide debounce length (proposed 10–15 min) and whether to also fix the stored
+  `rainingNow` at ingest or rely purely on the read-layer computation.

--- a/docs/issues/HLW-011-normalize-raining.md
+++ b/docs/issues/HLW-011-normalize-raining.md
@@ -1,9 +1,9 @@
 # HLW-011: Normalize "raining now" (rate-based + debounce)
 
-- **Status:** proposed
+- **Status:** in-progress (built + verified by replay)
 - **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/13
 - **Branch:** `feat/HLW-011-normalize-raining`
-- **PR:** (open when the work is ready)
+- **PR:** (opened from this branch)
 - **Created:** 2026-08-12
 
 ## Summary
@@ -32,18 +32,27 @@ easing: 22:56 0.165 → 22:57 0.118 → 22:59 0.047               (decaying)
 
 ## Plan
 
-- [ ] Base "raining now" on `hourlyrainin > 0` (rate) instead of the tip delta.
-- [ ] Debounce: stay Raining until the rate has read 0 for ~10–15 min; only then Dry.
-- [ ] Compute in the read API (latest reading + a small recent-window query for the
-      debounce), decoupling from the fragile in-memory watermark.
-- [ ] `lastRainAt` = last time the rate was > 0.
-- [ ] Verify against the recorded flapping window (should read steady Raining through it).
+- [x] Base "raining now" on `hourlyrainin > 0` (rate) instead of the tip delta.
+- [x] Debounce (`RAIN_DEBOUNCE_MIN`, default 15, env-tunable): stay Raining until the
+      rate has read 0 for the whole window; only then Dry.
+- [x] Compute in the read API — new pure `rainState(recent, latest)` + a small
+      `rainWindow()` query in `/api/current`, decoupled from the in-memory watermark.
+- [x] `lastRainAt` = last reading with rate > 0. Also expose `rain.rateInHr`.
+- [x] Verify against the recorded flapping window.
+
+## Verification (replay of the recorded 22:43–22:59 monsoon, no AWS needed)
+
+- OLD logic: **8** Dry↔Raining flips; **7** false "Dry" readings mid-storm.
+- NEW logic: **2** flips (clean onset + clean end), **0** false "Dry", stayed Raining
+  through the 5-min data gap, flipped to Dry at 23:15 (15 min after last rain).
 
 ## Acceptance criteria
 
-- [ ] During continuous rain the section stays "Raining" (no minute-to-minute flips).
-- [ ] Flips to "Dry" only after the debounce window with no rain rate.
-- [ ] Backed by a replay of the 22:43–22:59 data (0 spurious Dry readings).
+- [x] During continuous rain the section stays "Raining" (no minute-to-minute flips).
+- [x] Flips to "Dry" only after the debounce window with no rain rate.
+- [x] Backed by a replay of the 22:43–22:59 data (0 spurious Dry readings).
+- [ ] Live end-to-end (deployed) — pending deploy approval (and/or `aws sso login`
+      for a local dev-server check once HLW-012 lands).
 
 ## Notes
 

--- a/ingest/src/read.js
+++ b/ingest/src/read.js
@@ -18,6 +18,7 @@ import { getWater } from "./water.js";
 const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 const TABLE = process.env.TABLE_NAME;
 const STATION = (process.env.STATION_KEY || "").split(",")[0].trim();
+const RAIN_DEBOUNCE_MIN = Number(process.env.RAIN_DEBOUNCE_MIN || 15); // stay "raining" until the rate has read 0 this long
 
 const obsPk = (mm) => `OBS#${STATION}#${mm}`;
 const ym = (d) => d.toISOString().slice(0, 7);
@@ -97,6 +98,38 @@ async function series(hours) {
   return items;
 }
 
+// Recent readings (last `minutes`) for the rain debounce — small, edge-cached query.
+async function rainWindow(minutes) {
+  const now = new Date();
+  const startISO = new Date(now - minutes * 60e3).toISOString().slice(0, 19) + "Z";
+  const months = [ym(new Date(now - minutes * 60e3)), ym(now)].filter((v, i, a) => a.indexOf(v) === i);
+  const items = [];
+  for (const mm of months) {
+    const r = await ddb.send(new QueryCommand({
+      TableName: TABLE,
+      KeyConditionExpression: "pk = :pk AND sk >= :s",
+      ExpressionAttributeValues: { ":pk": obsPk(mm), ":s": startISO },
+      ProjectionExpression: "sk, hourlyrainin, lastRainAt",
+    }));
+    items.push(...(r.Items || []));
+  }
+  items.sort((a, b) => (a.sk < b.sk ? -1 : 1));
+  return items;
+}
+
+// Normalize "raining now". This station reports `hourlyrainin` as a rain RATE (it
+// exceeds the daily/total counters and decays smoothly), so key off that instead of
+// the tipping-bucket delta — which only ticks when the 0.01" bucket tips and so flaps
+// Dry↔Raining between tips. Debounce over the window so a tip gap / dropout can't flip
+// it to Dry mid-storm; only go Dry after the rate has been 0 for the whole window.
+export function rainState(recent, latest) {
+  const rate = (r) => (r && typeof r.hourlyrainin === "number" ? r.hourlyrainin : 0);
+  const wet = (recent || []).filter((r) => rate(r) > 0);
+  const rainingNow = rate(latest) > 0 || wet.length > 0;
+  const lastRainAt = wet.length ? wet[wet.length - 1].sk : (latest?.lastRainAt ?? null);
+  return { rainingNow, rateInHr: rate(latest) || null, lastRainAt };
+}
+
 export const handler = async (event) => {
   const method = event?.requestContext?.http?.method || "GET";
   const path = event?.rawPath || event?.requestContext?.http?.path || "/";
@@ -109,6 +142,7 @@ export const handler = async (event) => {
       if (!it) return res(200, { station: STATION, reading: null }, 15);
       const tf = it.tempf, rh = it.humidity;
       const ageSec = it.receivedAt ? (Date.now() - Date.parse(it.receivedAt)) / 1000 : null;
+      const rain = rainState(await rainWindow(RAIN_DEBOUNCE_MIN), it);
       return res(200, {
         station: STATION,
         observedAt: it.dateutc,
@@ -122,7 +156,7 @@ export const handler = async (event) => {
         pressureInHg: it.baromrelin,
         uv: it.uv,
         solarWm2: it.solarradiation,
-        rain: { rainingNow: !!it.rainingNow, lastRainAt: it.lastRainAt ?? null, todayIn: it.dailyrainin, monthIn: it.monthlyrainin, yearIn: it.yearlyrainin },
+        rain: { rainingNow: rain.rainingNow, rateInHr: rain.rateInHr, lastRainAt: rain.lastRainAt, todayIn: it.dailyrainin, monthIn: it.monthlyrainin, yearIn: it.yearlyrainin },
       }, 30);
     }
 


### PR DESCRIPTION
Fixes the "raining now" section flapping Dry↔Raining every minute during steady rain.

## Root cause
`rainingNow` was true only when the all-time **tipping-bucket** counter (`totalrainin`) increased since the *previous single reading*. The bucket tips in 0.01″ steps every 1–8 min, so between tips it read **Dry** even in a downpour.

## Fix
- Key off **`hourlyrainin`**, which this station reports as a rain **rate** (exceeds the daily/total counters, decays smoothly, `0.000` only when dry).
- New pure **`rainState(recent, latest)`** + a small **`rainWindow()`** query in `/api/current`, with a **debounce** (`RAIN_DEBOUNCE_MIN`, default 15, env-tunable) so a tip gap / dropout can't flip it to Dry mid-storm.
- `lastRainAt` = last reading with rate > 0; also exposes `rain.rateInHr`.
- **Response shape unchanged** → no frontend change.

## Verification — replay of the recorded 22:43–22:59 monsoon (no AWS needed)
| | Old | New |
|---|---|---|
| Dry↔Raining flips | **8** | **2** |
| False "Dry" during rain | 7 | **0** |
| Through the 5-min data gap | flapped | stayed Raining |
| Flips to Dry | erratic | 23:15 (15 min after last rain) |

## Deploy
Read-Lambda change — **needs a `sam deploy` to take effect** (gated; will ask before deploying). Live/local end-to-end check pending SSO refresh / HLW-012 merge.

Refs #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)