### PR TITLE
HLW-002: pin USBR RISE dam-release ids (Davis + Parker)

### DIFF
--- a/docs/issues/HLW-002-rise-dam-releases.md
+++ b/docs/issues/HLW-002-rise-dam-releases.md
@@ -1,0 +1,19 @@
+# HLW-002: Pin USBR RISE dam-release ids (Davis + Parker)
+
+- **Status:** proposed
+- **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/3
+- **Branch:** `feat/HLW-002-rise-dam-releases`
+- **PR:** (open when the work is ready)
+- **Created:** 2026-08-12
+
+## Summary
+
+Lake levels show live from USGS, but Davis/Parker Dam releases read dashes. Find the USBR RISE result-item ids for each dam's release (cfs), set RISE_DAVIS_ID / RISE_PARKER_ID, and confirm real inflow/outflow. Unblocks HLW-003.
+
+## Plan
+
+See issue #3 for detail. Per CLAUDE.md, the implementation plan is presented for approval before any code.
+
+## Acceptance criteria
+
+- [ ] finalized when picked up

--- a/docs/issues/HLW-002-rise-dam-releases.md
+++ b/docs/issues/HLW-002-rise-dam-releases.md
@@ -1,19 +1,55 @@
 # HLW-002: Pin USBR RISE dam-release ids (Davis + Parker)
 
-- **Status:** proposed
+- **Status:** in-progress (ids pinned + wired; live values pending RISE cooldown)
 - **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/3
 - **Branch:** `feat/HLW-002-rise-dam-releases`
-- **PR:** (open when the work is ready)
+- **PR:** (opened from this branch)
 - **Created:** 2026-08-12
 
 ## Summary
 
-Lake levels show live from USGS, but Davis/Parker Dam releases read dashes. Find the USBR RISE result-item ids for each dam's release (cfs), set RISE_DAVIS_ID / RISE_PARKER_ID, and confirm real inflow/outflow. Unblocks HLW-003.
+Lake levels are live from USGS, but Davis/Parker Dam releases read "—" because the
+USBR RISE catalog ids weren't set. Found and pinned them.
 
-## Plan
+## The ids (from the RISE catalog)
 
-See issue #3 for detail. Per CLAUDE.md, the implementation plan is presented for approval before any code.
+RISE structure: location → catalog-records → catalog-items. The daily
+"Lake/Reservoir Release - Total (cfs)" items live under each dam's **Water Operations
+Monitoring** record:
+
+| What | RISE item | Source record |
+|---|---|---|
+| **Davis Dam release** (inflow to Havasu) | **6135** | Lake Mohave record 4369 |
+| **Parker Dam release** (outflow downstream) | **6130** | Lake Havasu record 4371 |
+| 🎁 Lake Havasu water temp (°F) | 6127 | record 4371 |
+| 🎁 Lake Mohave water temp (°F) | 6132 | record 4369 |
+| Lake Havasu elevation (ft) | 6128 | record 4371 |
+| Lake Mohave elevation (ft) | 6133 | record 4369 |
+
+## Fixes in this change
+
+- Pinned `RISE_DAVIS_ID=6135`, `RISE_PARKER_ID=6130` (env-overridable defaults).
+- **Bug fix:** RISE rejects `Accept: application/json` with a 406 — it requires
+  `application/vnd.api+json`. Corrected the header (this is why releases would always
+  have read null before).
+- URL-encoded the `order[dateTime]=desc` sort param.
+
+## Verification
+
+- Lake levels (USGS): Lake Havasu 452 ft (full), Lake Mohave 642.6 ft — live. ✅
+- RISE endpoint + header + parser validated: water-temp items 6127/6132 returned
+  87.6°F / 75.8°F. ✅
+- Live Davis/Parker cfs: not yet confirmed from this machine — heavy probing got my IP
+  temporarily throttled (HTTP 000). Will confirm on the dev server (after cooldown) /
+  on deploy; the code path is proven by the temp items above.
+
+## Bonus for HLW-013
+
+RISE gives us **water temperature** (6127/6132) — the one gap I'd flagged as having no
+free live source. Add it to the /water page.
 
 ## Acceptance criteria
 
-- [ ] finalized when picked up
+- [x] Davis + Parker release ids found and pinned.
+- [x] RISE Accept-header bug fixed.
+- [ ] Live cfs confirmed via `/api/water` (dev server / deploy) once RISE un-throttles.

--- a/ingest/src/water.js
+++ b/ingest/src/water.js
@@ -16,6 +16,11 @@
 const UA = process.env.NWS_USER_AGENT || "HavasuLakeWeather/1.0 (+https://havasulakeweather.com)";
 const HAVASU_DATUM = 402.85; // ft, gage-height → NAVD88 water-surface elevation for 09427500
 const HAVASU_FULL = 450;     // ~full pool (Reclamation datum); used only for a coarse status
+// USBR RISE catalog item ids — daily "Lake/Reservoir Release - Total" (cfs), pinned:
+//   Davis Dam release  = inflow to Lake Havasu  (RISE item 6135, Lake Mohave record 4369)
+//   Parker Dam release = outflow downstream      (RISE item 6130, Lake Havasu record 4371)
+const RISE_DAVIS_ID = process.env.RISE_DAVIS_ID || "6135";
+const RISE_PARKER_ID = process.env.RISE_PARKER_ID || "6130";
 
 const now = () => new Date().toISOString();
 
@@ -41,11 +46,11 @@ async function usgsLatest(service, site, pcode, timeoutMs = 4500) {
 // USBR RISE release (cfs). Item id pinned via env at go-live; null until then.
 async function riseRelease(itemId, name, timeoutMs = 4500) {
   if (!itemId) return null;
-  const url = `https://data.usbr.gov/rise/api/result?itemId=${itemId}&order[dateTime]=desc&itemsPerPage=1`;
+  const url = `https://data.usbr.gov/rise/api/result?itemId=${itemId}&order%5BdateTime%5D=desc&itemsPerPage=1`;
   const ctrl = new AbortController();
   const t = setTimeout(() => ctrl.abort(), timeoutMs);
   try {
-    const r = await fetch(url, { headers: { accept: "application/json" }, signal: ctrl.signal });
+    const r = await fetch(url, { headers: { accept: "application/vnd.api+json" }, signal: ctrl.signal });
     if (!r.ok) throw new Error(`RISE ${itemId} -> ${r.status}`);
     const j = await r.json();
     const rec = (j.data || [])[0];
@@ -83,8 +88,8 @@ async function getLive() {
     name: "Lake Mohave", elevationFt: +moh.value.toFixed(2), observedAt: moh.at, datum: "NGVD29",
   } : null;
   const [inflow, outflow] = await Promise.all([
-    riseRelease(process.env.RISE_DAVIS_ID, "Davis Dam release"),
-    riseRelease(process.env.RISE_PARKER_ID, "Parker Dam release"),
+    riseRelease(RISE_DAVIS_ID, "Davis Dam release"),
+    riseRelease(RISE_PARKER_ID, "Parker Dam release"),
   ]);
   const notes = [];
   if (lake && lake.status === "low") notes.push("Lake Havasu is running below its normal band.");


### PR DESCRIPTION
Makes `/api/water` return **real Davis/Parker dam releases** instead of "—".

## Found the ids (RISE catalog dig)
RISE structure is location → catalog-records → catalog-items. The daily "Release - Total (cfs)" lives under each dam's **Water Operations Monitoring** record:
- **Davis Dam release** (inflow to Havasu) → RISE item **6135** (Lake Mohave rec 4369)
- **Parker Dam release** (outflow) → RISE item **6130** (Lake Havasu rec 4371)

## Fixes
- Pin `RISE_DAVIS_ID=6135` / `RISE_PARKER_ID=6130` (env-overridable).
- **Bug:** RISE 406s on `Accept: application/json`; it needs `application/vnd.api+json`. Fixed — this is why releases always read null before.
- URL-encoded the `order[dateTime]` sort param.

## Verified
- USGS lake levels live (Havasu 452 ft full, Mohave 642.6 ft). ✅
- RISE endpoint/header/parser proven by the water-temp items (6127 = 87.6°F, 6132 = 75.8°F). ✅
- Live Davis/Parker cfs not yet confirmed from my machine — heavy probing temporarily throttled this IP (HTTP 000). Will confirm on the dev server / deploy.

## 🎁 Bonus for HLW-013
RISE also carries **water temperature** (Havasu 6127, Mohave 6132) — the gap with no free live source. We can add it to the /water page.

**No deploy** (gated) — this rides along when we ship the /water page.

Refs #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)