### PR TITLE
HLW-015: store lake & dam snapshots + acre-feet storage

### DIFF
--- a/docs/issues/HLW-015-store-water-data.md
+++ b/docs/issues/HLW-015-store-water-data.md
@@ -1,0 +1,63 @@
+# HLW-015: Store lake & dam data (daily snapshots) + acre-feet storage
+
+- **Status:** in-progress (built + previewed locally)
+- **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/24
+- **Branch:** `feat/HLW-015-store-water-data`
+- **PR:** (opened from this branch)
+- **Created:** 2026-08-18
+
+## Summary
+
+We were fetching lake/dam data live on every request (USGS + USBR RISE), edge-cached but
+never persisted. Two problems: (1) no history of our own accumulating, and (2) the page
+led with **surface elevation in ft**, which reads like water *depth* to someone who
+doesn't know these gages. This ticket adds a scheduled snapshot writer, makes `/api/water`
+read from those snapshots (live fallback), and surfaces **storage in acre-feet** so the ft
+number is unambiguous.
+
+## What was built
+
+- **`ingest/src/water-ingest.js`** — new scheduled handler. Calls `getLive()` and upserts
+  one daily snapshot to DynamoDB (`pk = WATER#DAILY`, `sk = <YYYY-MM-DD>`): Havasu/Mohave
+  elevation, **storage (acre-ft)**, water temp, and Davis/Parker releases. Idempotent per
+  UTC day; skips writing an all-null snapshot when every upstream source hiccups.
+- **`template.yaml`** — `WaterIngestFunction` (`havasu-weather-water-ingest`, Timeout 30,
+  `rate(6 hours)`, DynamoDBCrudPolicy, `TABLE_NAME` env) + its log group.
+- **`ingest/src/water.js`**:
+  - `getLive()` now also fetches **storage** — RISE items `6129` (Havasu) / `6134` (Mohave)
+    — and returns `storageAf` on `lake`/`upstream`.
+  - **`riseNum()` date-scoped** (`dateTime[after]` = 20 days ago, asc, latest point). This
+    fixes the RISE hang on the 90-year storage/elevation series (same class of bug as the
+    HLW-016 release-query hotfix) and keeps temps/levels/storage fast.
+  - `getFromDb()` + `snapshotsToResponse()` — query the last ~35 `WATER#DAILY` snapshots and
+    rebuild the `/api/water` shape (lake/upstream/inflow/outflow/series/warnings).
+  - `getWater()` is now **DB-first**: return stored snapshots when present, else fall back to
+    `getLive()`. (Until the first ingest runs, `source: live`.)
+- **`web/water.html`** — Lake Havasu card leads with **"Surface elevation"**, the big ft
+  number, and the clarifier *"height of the water above sea level — not depth
+  (full pool ≈ 450 ft)"*; adds a **Storage (volume) … acre-ft** metric. Mohave relabeled
+  "Surface elev".
+- SW bumped to `havasu-wx-v16`.
+
+## Local verification (npm run dev)
+
+- `getWater("normal")` mock → `lake.storageAf 619000`, `upstream.storageAf 1650000`.
+- Live `/api/water` → Havasu **451.96 ft / 541,741 acre-ft / 87.6°F**, Mohave 642.38 ft /
+  1,743,320 acre-ft, Davis 4,429 (low), Parker 8,630 (normal); `source: live` (DB empty).
+- Snapshot the ingest would write: `davisCfs 4429, havasuStorageAf 541741, havasuElevFt 451.96`.
+- `/water` page renders storage + the "not depth" note; 0 console errors (Playwright).
+
+## Acceptance criteria
+
+- [x] Scheduled writer persists daily lake/dam snapshots incl. **acre-feet storage**.
+- [x] `/api/water` reads snapshots first, falls back to live.
+- [x] Page shows storage in acre-ft and clarifies ft = elevation, not depth.
+- [ ] Deployed; first ingest run confirmed writing `WATER#DAILY` (gated on Chad's approval).
+- [ ] `/api/water` confirmed serving `source: db` in prod after first run.
+
+## Notes / follow-ups
+
+- Snapshots are our own history from day one; the ~90yr RISE record is only used for the
+  seasonal baselines (HLW-014), not backfilled here. A later ticket could backfill history.
+- Mohave storage is stored but not shown on the card (kept compact); easy to surface later.
+- Retention: snapshots are tiny; on-demand DynamoDB keeps this free for decades.

--- a/ingest/src/water-ingest.js
+++ b/ingest/src/water-ingest.js
@@ -1,0 +1,48 @@
+/**
+ * Havasu Lake Weather — lake & river ingest (scheduled).
+ *
+ * Pulls the current lake levels, storage (acre-ft), water temps, and Davis/Parker
+ * releases (via getLive() in water.js) and writes ONE daily snapshot to DynamoDB
+ * (pk = WATER#DAILY, sk = <YYYY-MM-DD>). /api/water then reads from these snapshots
+ * instead of hitting USGS/RISE on the hot path — fast, reliable, and it accumulates
+ * our own history. Idempotent per day (each run upserts today's snapshot).
+ */
+
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, PutCommand } from "@aws-sdk/lib-dynamodb";
+import { getLive } from "./water.js";
+
+const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}), { marshallOptions: { removeUndefinedValues: true } });
+const TABLE = process.env.TABLE_NAME;
+
+export const handler = async () => {
+  const w = await getLive();
+  const lake = w.lake || {}, up = w.upstream || {};
+  const date = new Date().toISOString().slice(0, 10); // UTC day; upsert keeps one/day
+
+  const item = {
+    pk: "WATER#DAILY",
+    sk: date,
+    date,
+    updatedAt: new Date().toISOString(),
+    havasuElevFt: lake.elevationFt ?? null,
+    havasuStorageAf: lake.storageAf ?? null,
+    havasuTempF: lake.waterTempF ?? null,
+    mohaveElevFt: up.elevationFt ?? null,
+    mohaveStorageAf: up.storageAf ?? null,
+    mohaveTempF: up.waterTempF ?? null,
+    davisCfs: w.inflow ? w.inflow.cfs : null,
+    parkerCfs: w.outflow ? w.outflow.cfs : null,
+  };
+
+  // Skip writing an all-null snapshot (e.g. every upstream source hiccupped).
+  const anyValue = [item.havasuElevFt, item.davisCfs, item.parkerCfs, item.havasuStorageAf].some((v) => v != null);
+  if (!anyValue) {
+    console.error(JSON.stringify({ msg: "water-ingest-empty", date }));
+    return { stored: null, reason: "no-values" };
+  }
+
+  await ddb.send(new PutCommand({ TableName: TABLE, Item: item }));
+  console.log(JSON.stringify({ msg: "water-stored", date, davisCfs: item.davisCfs, parkerCfs: item.parkerCfs, havasuStorageAf: item.havasuStorageAf, havasuElevFt: item.havasuElevFt }));
+  return { stored: date };
+};

--- a/ingest/src/water.js
+++ b/ingest/src/water.js
@@ -14,6 +14,12 @@
  */
 
 import { readFileSync } from "node:fs";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, QueryCommand } from "@aws-sdk/lib-dynamodb";
+
+const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+const WATER_TABLE = process.env.TABLE_NAME;
+const WATER_PK = "WATER#DAILY"; // one snapshot per day (levels, storage, temps, releases)
 
 // Seasonal baselines (monthly percentiles from ~decades of RISE history) used to
 // classify releases as low / normal / high for the current month — see HLW-014.
@@ -29,6 +35,8 @@ const RISE_DAVIS_ID = process.env.RISE_DAVIS_ID || "6135";
 const RISE_PARKER_ID = process.env.RISE_PARKER_ID || "6130";
 const RISE_HAVASU_TEMP = process.env.RISE_HAVASU_TEMP || "6127"; // Lake Havasu water temp (DegF)
 const RISE_MOHAVE_TEMP = process.env.RISE_MOHAVE_TEMP || "6132"; // Lake Mohave water temp (DegF)
+const RISE_HAVASU_STORAGE = process.env.RISE_HAVASU_STORAGE || "6129"; // Lake Havasu storage (acre-ft)
+const RISE_MOHAVE_STORAGE = process.env.RISE_MOHAVE_STORAGE || "6134"; // Lake Mohave storage (acre-ft)
 
 const now = () => new Date().toISOString();
 
@@ -53,17 +61,23 @@ async function usgsLatest(service, site, pcode, timeoutMs = 4500) {
 
 // USBR RISE — latest daily value for a catalog item. RISE requires the JSON:API media
 // type (Accept: application/vnd.api+json) — application/json returns a 406.
-async function riseNum(itemId, timeoutMs = 4500) {
+async function riseNum(itemId, timeoutMs = 5000) {
   if (!itemId) return null;
-  const url = `https://data.usbr.gov/rise/api/result?itemId=${itemId}&order%5BdateTime%5D=desc&itemsPerPage=1`;
+  // Date-scope the query — a plain order=desc hangs on the ~90-year series (storage,
+  // elevation). We fetch recent points and take the latest.
+  const after = new Date(Date.now() - 20 * 86400e3).toISOString().slice(0, 10);
+  const url = `https://data.usbr.gov/rise/api/result?itemId=${itemId}&itemsPerPage=40&dateTime%5Bafter%5D=${after}`;
   const ctrl = new AbortController();
   const t = setTimeout(() => ctrl.abort(), timeoutMs);
   try {
     const r = await fetch(url, { headers: { accept: "application/vnd.api+json" }, signal: ctrl.signal });
     if (!r.ok) throw new Error(`RISE ${itemId} -> ${r.status}`);
-    const a = ((await r.json()).data || [])[0]?.attributes;
-    const v = a ? parseFloat(a.result) : NaN;
-    return Number.isFinite(v) ? { value: v, at: a.dateTime } : null;
+    const pts = ((await r.json()).data || [])
+      .map((x) => ({ at: x.attributes.dateTime, value: parseFloat(x.attributes.result) }))
+      .filter((p) => p.at && Number.isFinite(p.value));
+    if (!pts.length) return null;
+    pts.sort((a, b) => (a.at < b.at ? -1 : 1));
+    return pts[pts.length - 1];
   } catch (e) {
     return null;
   } finally {
@@ -151,25 +165,28 @@ function warningsFor(lake, inflow, outflow) {
   return w;
 }
 
-async function getLive() {
+export async function getLive() {
   const settle = async (p) => { try { return await p; } catch { return null; } };
   const month = new Date().getUTCMonth() + 1;
-  const [hav, moh, davisS, parkerS, havTemp, mohTemp] = await Promise.all([
+  const [hav, moh, davisS, parkerS, havTemp, mohTemp, havStore, mohStore] = await Promise.all([
     settle(usgsLatest("iv", "09427500", "00065", 8000)),  // Lake Havasu gage height
     settle(usgsLatest("dv", "09422500", "62614", 8000)),  // Lake Mohave elevation (NGVD29)
     settle(riseSeries(RISE_DAVIS_ID, 30)),                 // Davis release (current + chart)
     settle(riseSeries(RISE_PARKER_ID, 30)),                // Parker release (current + chart)
     settle(riseNum(RISE_HAVASU_TEMP)),
     settle(riseNum(RISE_MOHAVE_TEMP)),
+    settle(riseNum(RISE_HAVASU_STORAGE)),                  // acre-ft
+    settle(riseNum(RISE_MOHAVE_STORAGE)),                  // acre-ft
   ]);
   const elev = hav ? +(hav.value + HAVASU_DATUM).toFixed(2) : null;
   const lake = hav ? {
     name: "Lake Havasu", elevationFt: elev, gageFt: hav.value, fullPoolFt: HAVASU_FULL,
-    status: lakeStatus(elev), waterTempF: havTemp ? +havTemp.value.toFixed(1) : null,
-    observedAt: hav.at, datum: "NAVD88",
+    status: lakeStatus(elev), storageAf: havStore ? Math.round(havStore.value) : null,
+    waterTempF: havTemp ? +havTemp.value.toFixed(1) : null, observedAt: hav.at, datum: "NAVD88",
   } : null;
   const upstream = moh ? {
     name: "Lake Mohave", elevationFt: +moh.value.toFixed(2),
+    storageAf: mohStore ? Math.round(mohStore.value) : null,
     waterTempF: mohTemp ? +mohTemp.value.toFixed(1) : null, observedAt: moh.at, datum: "NGVD29",
   } : null;
   const inflow = seriesToRelease(davisS, "Davis Dam release", NORMALS.davisRelease, month);
@@ -179,12 +196,54 @@ async function getLive() {
   return { source: "live", lake, upstream, inflow, outflow, series: buildSeries(davisS, parkerS), warnings: warningsFor(lake, inflow, outflow), notes };
 }
 
+// Read the latest stored snapshot (+ recent series) from DynamoDB — populated by the
+// scheduled water-ingest so /api/water is fast and doesn't hit RISE at request time.
+// Returns null if nothing is stored yet (then we fall back to a live fetch).
+async function getFromDb() {
+  try {
+    const r = await ddb.send(new QueryCommand({
+      TableName: WATER_TABLE,
+      KeyConditionExpression: "pk = :p",
+      ExpressionAttributeValues: { ":p": WATER_PK },
+      ScanIndexForward: false, Limit: 35,
+    }));
+    const items = r.Items || [];
+    return items.length ? snapshotsToResponse(items) : null;
+  } catch (e) {
+    console.error(JSON.stringify({ msg: "water-db-read-fail", error: String(e && e.message || e) }));
+    return null;
+  }
+}
+
+function snapshotsToResponse(items) {
+  const latest = items[0];               // newest first
+  const asc = items.slice().reverse();   // oldest -> newest
+  const month = new Date().getUTCMonth() + 1;
+  const lake = latest.havasuElevFt != null ? {
+    name: "Lake Havasu", elevationFt: latest.havasuElevFt, fullPoolFt: HAVASU_FULL,
+    status: lakeStatus(latest.havasuElevFt), storageAf: latest.havasuStorageAf ?? null,
+    waterTempF: latest.havasuTempF ?? null, observedAt: latest.date, datum: "NAVD88",
+  } : null;
+  const upstream = latest.mohaveElevFt != null ? {
+    name: "Lake Mohave", elevationFt: latest.mohaveElevFt, storageAf: latest.mohaveStorageAf ?? null,
+    waterTempF: latest.mohaveTempF ?? null, observedAt: latest.date, datum: "NGVD29",
+  } : null;
+  const davisSeries = asc.filter((s) => s.davisCfs != null).map((s) => ({ date: s.date, value: s.davisCfs }));
+  const parkerSeries = asc.filter((s) => s.parkerCfs != null).map((s) => ({ date: s.date, value: s.parkerCfs }));
+  const inflow = seriesToRelease(davisSeries, "Davis Dam release", NORMALS.davisRelease, month);
+  const outflow = seriesToRelease(parkerSeries, "Parker Dam release", NORMALS.parkerRelease, month);
+  return { source: "stored", lake, upstream, inflow, outflow, series: buildSeries(davisSeries, parkerSeries), warnings: warningsFor(lake, inflow, outflow), notes: [] };
+}
+
 export async function getWater(mock) {
   const updatedAt = now();
   if (mock) {
     const make = MOCK[mock] || MOCK.normal;
     return { updatedAt, location: "Lake Havasu", source: "mock", mock, ...make() };
   }
+  const stored = await getFromDb();
+  if (stored && (stored.lake || stored.inflow)) return { updatedAt, location: "Lake Havasu", ...stored };
+  // fallback: live fetch (before the ingest has populated the store)
   try {
     return { updatedAt, location: "Lake Havasu", ...(await getLive()) };
   } catch (e) {
@@ -197,9 +256,10 @@ export async function getWater(mock) {
  * normal | low-lake | high-release. Fake, shaped like the live output.
  */
 function mockLake(elev, status) {
-  return { name: "Lake Havasu", elevationFt: elev, gageFt: +(elev - HAVASU_DATUM).toFixed(2), fullPoolFt: HAVASU_FULL, status, waterTempF: 88.0, observedAt: now(), datum: "NAVD88" };
+  const storeAf = status === "low" ? 555000 : status === "normal" ? 595000 : 619000;
+  return { name: "Lake Havasu", elevationFt: elev, gageFt: +(elev - HAVASU_DATUM).toFixed(2), fullPoolFt: HAVASU_FULL, status, storageAf: storeAf, waterTempF: 88.0, observedAt: now(), datum: "NAVD88" };
 }
-const moh = (elev) => ({ name: "Lake Mohave", elevationFt: elev, waterTempF: 76.0, observedAt: now(), datum: "NGVD29" });
+const moh = (elev) => ({ name: "Lake Mohave", elevationFt: elev, storageAf: 1650000, waterTempF: 76.0, observedAt: now(), datum: "NGVD29" });
 function mockSeries(dCur, pCur) {
   const dates = [], davisIn = [], parkerOut = [];
   const today = new Date();

--- a/template.yaml
+++ b/template.yaml
@@ -147,6 +147,38 @@ Resources:
       LogGroupName: !Sub "/aws/lambda/${PwsIngestFunction}"
       RetentionInDays: 14
 
+  # Scheduled snapshot of lake levels, storage (acre-ft), temps, and dam releases into
+  # DynamoDB (pk = WATER#DAILY). /api/water reads these instead of hitting RISE live.
+  WaterIngestFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: havasu-weather-water-ingest
+      Description: Scheduled snapshot of lake/dam data into DynamoDB
+      CodeUri: ingest/
+      Handler: src/water-ingest.handler
+      Timeout: 30
+      LoggingConfig:
+        LogFormat: JSON
+      Environment:
+        Variables:
+          TABLE_NAME: !Ref WeatherTable
+      Events:
+        Tick:
+          Type: Schedule
+          Properties:
+            Schedule: "rate(6 hours)"
+            Description: Snapshot lake & river data
+            Enabled: true
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref WeatherTable
+
+  WaterIngestLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${WaterIngestFunction}"
+      RetentionInDays: 14
+
   Distribution:
     Type: AWS::CloudFront::Distribution
     Properties:

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,5 +1,5 @@
 /* Havasu Lake Weather — service worker (installability + offline shell) */
-const CACHE = "havasu-wx-v15";
+const CACHE = "havasu-wx-v16";
 const SHELL = [
   "/", "/index.html", "/water.html", "/manifest.json",
   "/assets/icon-192.png", "/assets/icon-512.png", "/assets/icon-180.png",

--- a/web/water.html
+++ b/web/water.html
@@ -73,6 +73,9 @@
   .card .src{font-size:.66rem;font-weight:700;color:var(--ink-faint);text-transform:uppercase;letter-spacing:.05em;}
   .lk-elev{font-weight:800;font-size:2.2rem;color:var(--teal-deep);font-variant-numeric:tabular-nums;line-height:1.1;margin-top:4px;}
   .lk-elev small{font-size:.9rem;font-weight:700;color:var(--ink-soft);}
+  .lk-elev-label{font-size:.72rem;font-weight:700;color:var(--ink-faint);text-transform:uppercase;letter-spacing:.04em;}
+  .lk-elev-note{font-size:.72rem;font-weight:600;color:var(--ink-faint);margin-top:3px;line-height:1.35;}
+  .lk-elev-note b{color:var(--ink-soft);}
   .pill{font-size:.68rem;font-weight:800;padding:3px 10px;border-radius:999px;text-transform:uppercase;letter-spacing:.03em;}
   .pill-full,.pill-normal{background:rgba(47,185,196,.2);color:var(--teal-deep);}
   .pill-low{background:rgba(255,122,77,.2);color:var(--coral-deep);}
@@ -147,13 +150,15 @@
     <div id="warnings"></div>
     <section class="card">
       <h2>Lake Havasu <span class="src" id="lakeSrc"></span></h2>
+      <div class="lk-elev-label">Surface elevation</div>
       <div style="display:flex;align-items:center;gap:10px;flex-wrap:wrap;">
         <div class="lk-elev"><span id="lakeElev">--</span><small> ft</small></div>
         <span class="pill pill-full" id="lakePill">&mdash;</span>
       </div>
+      <div class="lk-elev-note">height of the water above sea level &mdash; <b>not depth</b> (full pool &asymp; 450 ft)</div>
       <div class="metrics">
+        <div class="metric"><div class="k">Storage (volume)</div><div class="v"><span id="lakeStorage">--</span><small> acre-ft</small></div></div>
         <div class="metric"><div class="k">Water temp</div><div class="v"><span id="lakeTemp">--</span><small>&deg;F</small></div></div>
-        <div class="metric"><div class="k">Full pool</div><div class="v">~450<small> ft</small></div></div>
       </div>
     </section>
 
@@ -172,7 +177,7 @@
     <section class="card">
       <h2>Lake Mohave <span class="src">upstream</span></h2>
       <div class="metrics">
-        <div class="metric"><div class="k">Elevation</div><div class="v"><span id="mohElev">--</span><small> ft</small></div></div>
+        <div class="metric"><div class="k">Surface elev</div><div class="v"><span id="mohElev">--</span><small> ft</small></div></div>
         <div class="metric"><div class="k">Water temp</div><div class="v"><span id="mohTemp">--</span><small>&deg;F</small></div></div>
       </div>
     </section>
@@ -252,6 +257,7 @@
     pill.className="pill pill-"+(st==="low"?"low":st==="unknown"?"normal":st);
     pill.textContent={full:"Full pool",normal:"Normal",low:"Low",unknown:"—"}[st]||"—";
     $("lakeTemp").textContent=lake.waterTempF!=null?lake.waterTempF.toFixed(1):"--";
+    $("lakeStorage").textContent=lake.storageAf!=null?fmt(lake.storageAf):"--";
     $("mohElev").textContent=up.elevationFt!=null?up.elevationFt.toFixed(1):"--";
     $("mohTemp").textContent=up.waterTempF!=null?up.waterTempF.toFixed(1):"--";
 


### PR DESCRIPTION
Closes #24.

## What
Persist our own lake/river history and make the elevation number unambiguous (ft = surface elevation above sea level, **not depth**).

- **`ingest/src/water-ingest.js`** (new): scheduled handler upserts one daily `WATER#DAILY` snapshot — Havasu/Mohave elevation, **storage (acre-ft)**, water temp, Davis/Parker releases. Idempotent per UTC day; skips all-null snapshots.
- **`template.yaml`**: `WaterIngestFunction` (`rate(6 hours)`, DynamoDBCrudPolicy, Timeout 30) + log group.
- **`ingest/src/water.js`**: `getLive()` now fetches storage (RISE items 6129/6134) and returns `storageAf`; `riseNum()` date-scoped to fix the 90-yr series hang; adds `getFromDb()`/`snapshotsToResponse()`; `getWater()` is **DB-first** with live fallback.
- **`web/water.html`**: Lake Havasu card leads with "Surface elevation" + the *"not depth (full pool ≈ 450 ft)"* clarifier and a **Storage (volume) … acre-ft** metric; Mohave relabeled. SW → `havasu-wx-v16`.

## Local verification (`npm run dev`)
- Live `/api/water` → Havasu **451.96 ft / 541,741 acre-ft / 87.6°F**, Mohave 642.38 ft / 1,743,320 acre-ft, Davis 4,429 (low), Parker 8,630 (normal); `source: live` (DB empty until first ingest).
- `getWater("normal")` mock → `lake.storageAf 619000`.
- `/water` page renders storage + the "not depth" note; 0 console errors (Playwright).

## Deploy (gated — awaiting approval)
- Ingest stack: adds `WaterIngestFunction` + updates read/water Lambda (DB-first read).
- Site: `water.html` + `sw.js` (v16).
- Preserve `AllowedStationKeys` / `WuApiKey` via `--parameter-overrides` from the deployed Lambda env.
- After first scheduled run, `/api/water` should serve `source: db`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)