### PR TITLE
HLW-010: PWA "update available — refresh" toast

### DIFF
--- a/docs/issues/HLW-010-update-toast.md
+++ b/docs/issues/HLW-010-update-toast.md
@@ -1,0 +1,51 @@
+# HLW-010: PWA "update available — refresh" toast
+
+- **Status:** in-progress
+- **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/11
+- **Branch:** `feat/HLW-010-update-toast`
+- **PR:** (opened from this branch)
+- **Created:** 2026-08-20
+
+## Summary
+
+When a new service-worker version is waiting, show a small persistent "New version
+available — Refresh" toast so installed users pick up changes on tap instead of on some
+later reload. We already bump the SW cache (`havasu-wx-vN`) each deploy; this surfaces it.
+
+## Current state
+
+- `sw.js` calls `self.skipWaiting()` on install → a new SW activates immediately and
+  silently (nothing to prompt).
+- `index.html` registers the SW with no update handling; `water.html` doesn't register at all.
+- The existing `toast()` is a 2.2s auto-hiding, non-interactive pill (good for "Thanks",
+  not for an actionable prompt).
+
+## Plan
+
+1. **`sw.js`** — drop `skipWaiting()` from `install` so a new SW parks in the *waiting*
+   state (the hook for "update available"); add a `message` listener that calls
+   `self.skipWaiting()` on `SKIP_WAITING`; keep `clients.claim()`.
+2. **`web/sw-register.js`** (new, shared) — register `/sw.js`; detect an update via
+   `registration.waiting` and `updatefound → installed` (+ `controller` present, so first
+   installs don't prompt); show a self-contained, persistent, tappable toast; on tap
+   `postMessage('SKIP_WAITING')`; reload once on `controllerchange` (guarded against loops).
+   The toast builds its own DOM + inline styles so it works identically on both pages.
+3. **`index.html` / `water.html`** — include `sw-register.js`; remove the old inline
+   registration in `index.html` (now `water.html` gets registration too).
+4. Add `sw-register.js` to the SW `SHELL`; bump cache to `havasu-wx-v18`.
+
+## Tradeoff
+
+After this, updates wait for a tap (or for all tabs to close) instead of applying
+silently — which is the point of the toast, and better than the current invisible swap.
+
+## Acceptance criteria
+
+- [ ] Deploying a new SW version surfaces the toast for already-installed users.
+- [ ] Tapping Refresh activates the waiting worker and reloads once (no reload loop).
+- [ ] First-ever install does **not** show the toast.
+- [ ] Works on both `/` and `/water`; 0 console errors.
+
+## Out of scope
+
+- Auto-refresh without a tap (intentionally prompt-driven).

--- a/web/index.html
+++ b/web/index.html
@@ -807,7 +807,7 @@
 <script>
 /* PWA: service worker + install affordance */
 (function(){
-  if("serviceWorker" in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js").catch(function(){});});}
+  // SW registration + "update available" toast now live in /sw-register.js (HLW-010).
   var ua=navigator.userAgent;
   var isIos=/iphone|ipad|ipod/i.test(ua)||(navigator.platform==="MacIntel"&&navigator.maxTouchPoints>1);
   var iosOther=isIos&&/crios|fxios|edgios|opios/i.test(ua); // Chrome/Firefox/Edge/Opera on iOS
@@ -845,5 +845,6 @@
   }
 })();
 </script>
+<script src="/sw-register.js" defer></script>
 </body>
 </html>

--- a/web/sw-register.js
+++ b/web/sw-register.js
@@ -1,0 +1,62 @@
+/* Havasu Lake Weather — service-worker registration + "update available" toast (HLW-010).
+ * Included by index.html and water.html. Registers /sw.js; when a new SW version is waiting,
+ * shows a persistent, tappable toast. Tapping activates the waiting worker and reloads once
+ * (guarded against reload loops). Self-contained: builds its own toast DOM + styles, so it
+ * behaves identically on every page without per-page markup. */
+(function () {
+  if (!("serviceWorker" in navigator)) return;
+
+  var refreshing = false;
+  navigator.serviceWorker.addEventListener("controllerchange", function () {
+    if (refreshing) return;      // the waiting worker took control — reload once to pick it up
+    refreshing = true;
+    window.location.reload();
+  });
+
+  function showToast(onRefresh) {
+    if (document.getElementById("swUpdateToast")) return; // already showing
+    var wrap = document.createElement("div");
+    wrap.id = "swUpdateToast";
+    wrap.setAttribute("role", "status");
+    wrap.style.cssText = "position:fixed;left:50%;bottom:max(20px,env(safe-area-inset-bottom));" +
+      "transform:translateX(-50%) translateY(12px);z-index:2147483000;display:flex;align-items:center;gap:12px;" +
+      "background:#0a2b34;color:#eaf6f8;border:1px solid rgba(255,255,255,.18);border-radius:999px;" +
+      "padding:10px 12px 10px 18px;font:700 .88rem ui-rounded,'SF Pro Rounded','Segoe UI',system-ui,-apple-system,sans-serif;" +
+      "box-shadow:0 14px 40px -12px rgba(0,0,0,.7);opacity:0;transition:opacity .25s,transform .25s;";
+
+    var msg = document.createElement("span");
+    msg.textContent = "New version available";
+
+    var btn = document.createElement("button");
+    btn.type = "button";
+    btn.textContent = "Refresh";
+    btn.style.cssText = "cursor:pointer;border:0;border-radius:999px;padding:7px 15px;" +
+      "font:800 .82rem inherit;color:#04222a;background:#7fe6e2;";
+    btn.addEventListener("click", function () { btn.disabled = true; btn.textContent = "Updating…"; onRefresh(); });
+
+    wrap.appendChild(msg);
+    wrap.appendChild(btn);
+    document.body.appendChild(wrap);
+    requestAnimationFrame(function () { wrap.style.opacity = "1"; wrap.style.transform = "translateX(-50%) translateY(0)"; });
+  }
+
+  function promptUpdate(reg) {
+    if (reg.waiting) showToast(function () { reg.waiting.postMessage("SKIP_WAITING"); });
+  }
+
+  window.addEventListener("load", function () {
+    navigator.serviceWorker.register("/sw.js").then(function (reg) {
+      // An update may already be waiting (installed on a prior visit / another tab).
+      if (reg.waiting && navigator.serviceWorker.controller) promptUpdate(reg);
+      // Or one starts installing now — prompt once it finishes (and only if this isn't the
+      // first-ever install, i.e. a controller already exists).
+      reg.addEventListener("updatefound", function () {
+        var nw = reg.installing;
+        if (!nw) return;
+        nw.addEventListener("statechange", function () {
+          if (nw.state === "installed" && navigator.serviceWorker.controller) promptUpdate(reg);
+        });
+      });
+    }).catch(function () {});
+  });
+})();

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,13 +1,20 @@
 /* Havasu Lake Weather — service worker (installability + offline shell) */
-const CACHE = "havasu-wx-v17";
+const CACHE = "havasu-wx-v18";
 const SHELL = [
-  "/", "/index.html", "/water.html", "/manifest.json",
+  "/", "/index.html", "/water.html", "/manifest.json", "/sw-register.js",
   "/assets/icon-192.png", "/assets/icon-512.png", "/assets/icon-180.png",
   "/assets/venmo-qr.png", "/assets/cashapp-qr.png",
 ];
 
 self.addEventListener("install", (e) => {
-  e.waitUntil(caches.open(CACHE).then((c) => c.addAll(SHELL)).then(() => self.skipWaiting()));
+  // No skipWaiting() here — a new version parks in the "waiting" state so the page can
+  // surface an "update available" toast (HLW-010) and activate it on the user's tap.
+  e.waitUntil(caches.open(CACHE).then((c) => c.addAll(SHELL)));
+});
+
+// The page posts SKIP_WAITING when the user taps Refresh → activate this worker now.
+self.addEventListener("message", (e) => {
+  if (e.data === "SKIP_WAITING" || (e.data && e.data.type === "SKIP_WAITING")) self.skipWaiting();
 });
 
 self.addEventListener("activate", (e) => {

--- a/web/water.html
+++ b/web/water.html
@@ -396,5 +396,6 @@
   load(); setInterval(load,300000);
 })();
 </script>
+<script src="/sw-register.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
Closes #11.

Installed users currently get new versions via a silent swap on some later load. This surfaces a small **"New version available — Refresh"** toast when a new service-worker version is waiting, so updates land promptly on a tap.

## Changes
- **`sw.js`** — remove `skipWaiting()` from `install` so a new version parks in the *waiting* state; add a `message` listener that calls `self.skipWaiting()` on `SKIP_WAITING`; keep `clients.claim()`. Cache `v17 → v18`.
- **`web/sw-register.js`** (new, shared) — registers `/sw.js`; detects a waiting update (both the already-waiting case and `updatefound → installed`, guarded by `controller` so first installs don't prompt); shows a **self-contained, persistent, tappable** toast (builds its own DOM + inline styles, so it's identical on every page); on tap `postMessage('SKIP_WAITING')` and reloads once on `controllerchange` (loop-guarded).
- **`index.html`** — drop the inline registration, include `sw-register.js`. **`water.html`** — include it too (it previously registered no SW at all).

## Tradeoff
Updates now wait for a tap (or for all tabs to close) rather than swapping silently — which is the point of the toast.

## Verified in a real browser (Playwright)
1. First install → **no toast** (silent), SW activated + controlling.
2. Simulated deploy (bump cache) → reload → **toast appears** with a Refresh button, new SW waiting.
3. Tap **Refresh** → waiting worker activates, page **reloads once** (no loop), old cache purged (only `havasu-wx-v19` remained), toast clears.
4. **0 console errors.**

## Deploy (gated)
Site-only — `sw.js`, `sw-register.js`, `index.html`, `water.html`. No backend/infra change. Note: because the *current* live SW (v17) still has `skipWaiting`, the very first rollout to v18 applies the old way (silent); the toast kicks in for **subsequent** updates (v18 → v19+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)