### PR TITLE
HLW-019: 7-day forecast strip on the home page

### DIFF
--- a/docs/issues/HLW-019-seven-day-forecast.md
+++ b/docs/issues/HLW-019-seven-day-forecast.md
@@ -1,0 +1,38 @@
+# HLW-019: 7-day forecast strip on the home page
+
+- **Status:** in-progress (approved: compact strip)
+- **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/31
+- **Branch:** `feat/HLW-019-seven-day-forecast`
+- **PR:** (opened from this branch)
+- **Created:** 2026-08-21
+
+## Summary
+
+The Forecast card only shows today + a 12-hour hourly strip, even though the read Lambda
+**already fetches all 7 NWS days** (it just uses `daily[0]`). Add a compact **7-day strip**
+so the week is visible at a glance. No new data source — NWS tops out at 7 days and that's
+fine (see HLW-020 for why 10-day would need a different source; we chose 7).
+
+## Plan
+
+- **`ingest/src/nws.js`** — add a paired **`days`** array to the forecast response: iterate
+  the day/night periods, group by local date, and emit up to 7 `{date, weekday, hiF, loF,
+  precipProb, shortForecast, glyph, isDaytime}`. `hiF` from the daytime period, `loF` from
+  the night, `precipProb` = max of the two. Dependency-free condition **glyph** mapped from
+  the forecast text (☀ 🌤 ☁ 🌧 ⛈ 🌨 🌫). Keep `hourly` + `rainSoon` + `daily` unchanged.
+  Add `days` to the `rain`/`clear` mocks.
+- **`web/index.html`** — render a horizontal 7-day strip (weekday · glyph · hi° · lo° ·
+  precip%) under the hourly row in the Forecast card; scrolls on narrow screens. No external
+  icon images.
+- Bump `web/sw.js` cache.
+
+## Acceptance criteria
+
+- [ ] `/api/forecast` returns a `days` array (7 entries) with hi/lo/precip/glyph.
+- [ ] Home page shows the 7-day strip; `?mockForecast=rain` and `=clear` exercise it.
+- [ ] No external image/script dependencies added; 0 console errors.
+- [ ] Deploy: site + read Lambda (gated).
+
+## Out of scope
+
+- True 10-day (would need Open-Meteo — parked; NWS caps at 7). See HLW-020 for radar.

--- a/ingest/src/nws.js
+++ b/ingest/src/nws.js
@@ -138,6 +138,49 @@ function rainSoonFrom(hourly = []) {
   return { likely: at != null, withinHours, at, maxProbNext12h: maxProb };
 }
 
+// Collapse the NWS day/night periods into up to 7 calendar days for the forecast strip:
+// daytime period -> high, following night -> low, precip = max of the two. A dependency-free
+// condition glyph is mapped from the forecast text (no external icon images).
+const WEEKDAY = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+function glyphFor(text = "", day = true) {
+  const s = text.toLowerCase();
+  // Fully-qualified emoji (with U+FE0F where needed) so they render in color, not monochrome.
+  if (/thunder|t-?storm/.test(s)) return "⛈️";
+  if (/snow|flurr|wintry|sleet|blizzard/.test(s)) return "🌨️";
+  if (/rain|shower|drizzle/.test(s)) return "🌧️";
+  if (/fog|haze|smoke|mist/.test(s)) return "🌫️";
+  if (/(overcast|mostly cloudy|broken clouds)/.test(s)) return "☁️";
+  if (/(partly|mostly sunny|partly cloudy|few clouds|scattered clouds)/.test(s)) return day ? "🌤️" : "🌙";
+  if (/(sunny|clear|fair|hot)/.test(s)) return day ? "☀️" : "🌙";
+  return day ? "☀️" : "🌙";
+}
+function buildDays(periods = []) {
+  const byDate = new Map(); // localDate -> { day, night }
+  for (const p of periods) {
+    const date = (p.startTime || "").slice(0, 10); // NWS startTime carries the local offset
+    if (!date) continue;
+    if (!byDate.has(date)) byDate.set(date, {});
+    if (p.isDaytime) byDate.get(date).day = p; else byDate.get(date).night = p;
+  }
+  const out = [];
+  for (const [date, { day, night }] of byDate) {
+    const lead = day || night; // if today's daytime already passed, the night leads
+    const pd = pop(day), pn = pop(night);
+    out.push({
+      date,
+      weekday: WEEKDAY[new Date(`${date}T12:00:00Z`).getUTCDay()],
+      hiF: day ? day.temperature : null,
+      loF: night ? night.temperature : null,
+      precipProb: pd == null && pn == null ? null : Math.max(pd ?? 0, pn ?? 0),
+      shortForecast: (lead && lead.shortForecast) || "",
+      glyph: glyphFor(lead && lead.shortForecast, !!day),
+      isDaytime: !!day,
+    });
+    if (out.length >= 7) break;
+  }
+  return out;
+}
+
 export async function getForecast(mock) {
   const updatedAt = new Date().toISOString();
   if (mock) {
@@ -149,6 +192,7 @@ export async function getForecast(mock) {
     nwsFetch(`/gridpoints/${GRID}/forecast/hourly`),
   ]);
   const hourlyN = normHourly(hourly?.properties?.periods);
+  const periods = daily?.properties?.periods;
   return {
     updatedAt,
     location: LOCATION,
@@ -156,7 +200,8 @@ export async function getForecast(mock) {
     office: GRID.split("/")[0],
     rainSoon: rainSoonFrom(hourlyN),
     hourly: hourlyN,
-    daily: normDaily(daily?.properties?.periods),
+    daily: normDaily(periods),
+    days: buildDays(periods),
   };
 }
 
@@ -238,13 +283,31 @@ function mockDaily(wet) {
   ];
 }
 
+// Seven fake calendar days shaped like buildDays() output, for ?mockForecast=.
+function mockDays(wet) {
+  const hi = [108, 110, 107, 101, 105, 107, 109], lo = [82, 84, 81, 79, 80, 82, 83];
+  const sf = wet
+    ? ["Sunny", "Sunny", "Mostly Sunny", "Showers And Thunderstorms Likely", "Partly Sunny", "Sunny", "Sunny"]
+    : ["Sunny", "Sunny", "Sunny", "Mostly Sunny", "Sunny", "Sunny", "Sunny"];
+  const pp = wet ? [5, 5, 20, 60, 30, 10, 5] : [0, 0, 5, 10, 5, 0, 0];
+  const base = Date.now();
+  return sf.map((s, i) => {
+    const date = new Date(base + i * 86400e3).toISOString().slice(0, 10);
+    return {
+      date, weekday: WEEKDAY[new Date(`${date}T12:00:00Z`).getUTCDay()],
+      hiF: hi[i], loF: lo[i], precipProb: pp[i] || null,
+      shortForecast: s, glyph: glyphFor(s, true), isDaytime: true,
+    };
+  });
+}
+
 const MOCK_FORECAST = {
   "rain": () => {
     const hourly = mockHourly([10, 20, 40, 60, 70, 50, 30, 20, 10, 10, 5, 5], 104);
-    return { office: "VEF", rainSoon: rainSoonFrom(hourly), hourly, daily: mockDaily(true) };
+    return { office: "VEF", rainSoon: rainSoonFrom(hourly), hourly, daily: mockDaily(true), days: mockDays(true) };
   },
   "clear": () => {
     const hourly = mockHourly([0, 0, 1, 2, 1, 0, 0, 0, 0, 0, 0, 0], 103);
-    return { office: "VEF", rainSoon: rainSoonFrom(hourly), hourly, daily: mockDaily(false) };
+    return { office: "VEF", rainSoon: rainSoonFrom(hourly), hourly, daily: mockDaily(false), days: mockDays(false) };
   },
 };

--- a/web/index.html
+++ b/web/index.html
@@ -186,7 +186,7 @@
   .btn-primary:hover{transform:translateY(-2px);filter:brightness(1.05);}
   .btn .heart{width:18px;height:18px;}
 
-  .footer{margin-top:2px;text-align:center;color:#fff;text-shadow:0 1px 8px rgba(60,20,10,.45);font-size:.78rem;font-weight:650;opacity:.95;display:flex;flex-direction:column;gap:4px;}
+  .footer{text-align:center;color:#fff;text-shadow:0 1px 8px rgba(60,20,10,.45);font-size:.78rem;font-weight:650;opacity:.95;display:flex;flex-direction:column;gap:4px;}
 
   .support-fab{position:fixed;right:16px;bottom:max(16px,env(safe-area-inset-bottom));z-index:20;display:inline-flex;align-items:center;gap:8px;color:#2b1810;background:var(--glass-bg);border:1px solid var(--glass-brd);border-radius:999px;padding:11px 17px;font:inherit;font-family:var(--font);font-weight:800;cursor:pointer;box-shadow:var(--glass-shadow),inset 0 1px 0 var(--glass-hi);backdrop-filter:var(--blur);-webkit-backdrop-filter:var(--blur);}
   .support-fab .h{color:var(--coral-deep);}
@@ -261,7 +261,7 @@
   }
 
   /* ---- weather alerts (heat kept calm, flood/warnings loud) ---- */
-  .alerts{display:flex;flex-direction:column;gap:8px;margin-top:12px;}
+  .alerts{display:flex;flex-direction:column;gap:8px;}
   .alerts:empty{display:none;}
   .alert{display:flex;align-items:flex-start;gap:11px;border-radius:var(--radius-sm);padding:12px 14px;border:1px solid var(--glass-brd);backdrop-filter:var(--blur);-webkit-backdrop-filter:var(--blur);box-shadow:var(--glass-shadow);}
   .alert-ico{font-size:1.3rem;line-height:1.2;flex:none;}
@@ -279,7 +279,7 @@
   .alert-info.is-heat{background:linear-gradient(150deg,rgba(255,188,110,.42),rgba(255,222,150,.3));}
 
   /* ---- forecast strip (NWS) ---- */
-  .forecast{margin-top:14px;padding:16px 16px 14px;}
+  .forecast{padding:16px 16px 14px;}
   .fc-head{display:flex;align-items:baseline;justify-content:space-between;gap:10px;}
   .fc-head h2{margin:0;font-size:1.05rem;font-weight:800;}
   .fc-src{font-size:.7rem;font-weight:700;color:var(--ink-faint);text-transform:uppercase;letter-spacing:.05em;}
@@ -297,9 +297,8 @@
   /* ---- 7-day strip (HLW-019) ---- */
   .fc-days-lbl{margin-top:14px;font-size:.7rem;font-weight:800;color:var(--ink-faint);text-transform:uppercase;letter-spacing:.05em;}
   .fc-days-lbl[hidden]{display:none;}
-  .fc-days{display:flex;gap:6px;margin-top:8px;overflow-x:auto;padding-bottom:4px;-webkit-overflow-scrolling:touch;scrollbar-width:none;}
-  .fc-days::-webkit-scrollbar{display:none;}
-  .fc-day{flex:none;width:52px;display:flex;flex-direction:column;align-items:center;gap:2px;padding:9px 4px;border-radius:14px;background:var(--glass-bg-2);border:1px solid var(--glass-brd);}
+  .fc-days{display:grid;grid-template-columns:repeat(7,1fr);gap:5px;margin-top:8px;}
+  .fc-day{min-width:0;display:flex;flex-direction:column;align-items:center;gap:2px;padding:9px 3px;border-radius:14px;background:var(--glass-bg-2);border:1px solid var(--glass-brd);}
   .fc-day.today{background:rgba(15,127,143,.12);border-color:rgba(15,127,143,.3);}
   .fc-day .d{font-size:.7rem;font-weight:800;color:var(--ink-soft);}
   .fc-day .g{font-size:1.15rem;line-height:1.1;margin:1px 0;}
@@ -309,7 +308,7 @@
   .fc-day .p.dim{color:var(--ink-faint);font-weight:600;}
 
   /* ---- station check (our station vs a nearby PWS) ---- */
-  .compare{margin-top:14px;padding:16px;}
+  .compare{padding:16px;}
   .cmp-head{display:flex;align-items:baseline;justify-content:space-between;gap:10px;margin-bottom:6px;}
   .cmp-head h2{margin:0;font-size:1.05rem;font-weight:800;}
   .cmp-src{font-size:.7rem;font-weight:700;color:var(--ink-faint);text-transform:uppercase;letter-spacing:.05em;}
@@ -322,7 +321,7 @@
   /* ---- lake & river (USGS + USBR) ---- */
   /* NOTE: class is .lakeriver, NOT .water — .water is the background scene's lake element. */
   .lakeriver{margin-top:14px;padding:16px;}
-  .lakeriver-teaser{margin-top:14px;padding:13px 16px;display:flex;align-items:center;justify-content:space-between;gap:12px;text-decoration:none;color:inherit;cursor:pointer;transition:transform .15s ease;}
+  .lakeriver-teaser{padding:13px 16px;display:flex;align-items:center;justify-content:space-between;gap:12px;text-decoration:none;color:inherit;cursor:pointer;transition:transform .15s ease;}
   .lakeriver-teaser:hover{transform:translateY(-1px);}
   .wtr-t-left{display:flex;flex-direction:column;gap:2px;}
   .wtr-t-k{font-size:.7rem;font-weight:800;color:var(--ink-faint);text-transform:uppercase;letter-spacing:.05em;}

--- a/web/index.html
+++ b/web/index.html
@@ -294,6 +294,19 @@
   .fc-hour .t{font-size:1rem;font-weight:800;font-variant-numeric:tabular-nums;}
   .fc-hour .p{font-size:.7rem;font-weight:800;color:var(--teal);}
   .fc-hour .p.dim{color:var(--ink-faint);font-weight:600;}
+  /* ---- 7-day strip (HLW-019) ---- */
+  .fc-days-lbl{margin-top:14px;font-size:.7rem;font-weight:800;color:var(--ink-faint);text-transform:uppercase;letter-spacing:.05em;}
+  .fc-days-lbl[hidden]{display:none;}
+  .fc-days{display:flex;gap:6px;margin-top:8px;overflow-x:auto;padding-bottom:4px;-webkit-overflow-scrolling:touch;scrollbar-width:none;}
+  .fc-days::-webkit-scrollbar{display:none;}
+  .fc-day{flex:none;width:52px;display:flex;flex-direction:column;align-items:center;gap:2px;padding:9px 4px;border-radius:14px;background:var(--glass-bg-2);border:1px solid var(--glass-brd);}
+  .fc-day.today{background:rgba(15,127,143,.12);border-color:rgba(15,127,143,.3);}
+  .fc-day .d{font-size:.7rem;font-weight:800;color:var(--ink-soft);}
+  .fc-day .g{font-size:1.15rem;line-height:1.1;margin:1px 0;}
+  .fc-day .hi{font-size:.92rem;font-weight:800;font-variant-numeric:tabular-nums;}
+  .fc-day .lo{font-size:.78rem;font-weight:700;color:var(--ink-faint);font-variant-numeric:tabular-nums;}
+  .fc-day .p{font-size:.66rem;font-weight:800;color:var(--teal);}
+  .fc-day .p.dim{color:var(--ink-faint);font-weight:600;}
 
   /* ---- station check (our station vs a nearby PWS) ---- */
   .compare{margin-top:14px;padding:16px;}
@@ -429,6 +442,8 @@
       <div class="fc-chip" id="fcRain" hidden></div>
       <div class="fc-today" id="fcToday"></div>
       <div class="fc-hours" id="fcHours" aria-label="Next hours"></div>
+      <div class="fc-days-lbl" id="fcDaysLbl" hidden>Next 7 days</div>
+      <div class="fc-days" id="fcDays" aria-label="7-day forecast"></div>
     </section>
 
     <!-- TILES -->
@@ -749,6 +764,20 @@
       cell.innerHTML='<span class="h">'+esc(hourLbl(x.time))+'</span><span class="t">'+(x.tempF!=null?Math.round(x.tempF)+"°":"--")+'</span>'+pp;
       h.appendChild(cell);
     });
+    var days=d.days||[],dd=$("fcDays"),ddl=$("fcDaysLbl");
+    if(dd){
+      dd.innerHTML="";
+      days.forEach(function(x,i){
+        var cell=document.createElement("div");cell.className="fc-day"+(i===0?" today":"");
+        var pp=(x.precipProb!=null&&x.precipProb>0)?('<span class="p">'+x.precipProb+'%</span>'):'<span class="p dim">·</span>';
+        cell.innerHTML='<span class="d">'+(i===0?"Today":esc(x.weekday))+'</span>'+
+          '<span class="g">'+esc(x.glyph||"")+'</span>'+
+          '<span class="hi">'+(x.hiF!=null?Math.round(x.hiF)+"°":"--")+'</span>'+
+          '<span class="lo">'+(x.loF!=null?Math.round(x.loF)+"°":"--")+'</span>'+pp;
+        dd.appendChild(cell);
+      });
+      if(ddl)ddl.hidden=!days.length;
+    }
     $("fcSrc").textContent=d.source==="mock"?"demo data":"via NWS";
   }
 

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,5 +1,5 @@
 /* Havasu Lake Weather — service worker (installability + offline shell) */
-const CACHE = "havasu-wx-v18";
+const CACHE = "havasu-wx-v19";
 const SHELL = [
   "/", "/index.html", "/water.html", "/manifest.json", "/sw-register.js",
   "/assets/icon-192.png", "/assets/icon-512.png", "/assets/icon-180.png",


### PR DESCRIPTION
Closes #31.

The read Lambda already fetched all 7 NWS days but the page only used `daily[0]` (today + a 12-hour strip). This surfaces the week as a compact 7-day strip. **No new data source** — NWS caps at 7 days and that's fine (10-day would need Open-Meteo; parked).

## Changes
- **`ingest/src/nws.js`** — add a paired `days` array to `/api/forecast`: group the day/night periods by local date → up to 7 `{date, weekday, hiF, loF, precipProb, shortForecast, glyph, isDaytime}` (high from the daytime period, low from the night, precip = max). Dependency-free condition emoji glyphs (☀️ 🌤️ ☁️ 🌧️ ⛈️ 🌨️ 🌫️) mapped from the forecast text. Added to the `rain`/`clear` mocks.
- **`web/index.html`** — 7-day strip under the hourly row (weekday · glyph · hi° · lo° · precip%), **Today** highlighted, horizontal scroll on narrow screens. No external icon images.
- SW → `v19`.

## Local verification
- Real `/api/forecast` returns 7 days from NWS (live: 112–114°, all sunny).
- `?mockForecast=rain` / `=clear` exercise the strip (storm day shows ⛈️ 60%).
- Renders correctly, glyphs in color, "Today" first + highlighted (Playwright). No new external deps.

## Deploy (gated)
Site (`index.html`, `sw.js` v19) + read Lambda (`nws.js`). No infra change.
Note: **SSO token expired** locally — a `aws sso login --profile havasu` will be needed before deploying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)