### PR TITLE
HLW-023: Colorado cascade — Powell → Grand Canyon → Mead (Phase 1+2)

### DIFF
--- a/docs/issues/HLW-023-colorado-cascade.md
+++ b/docs/issues/HLW-023-colorado-cascade.md
@@ -1,0 +1,75 @@
+# HLW-023: Extend /water to the full Colorado cascade (Powell → Grand Canyon → Mead) + history
+
+- **Status:** proposed
+- **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/36
+- **Branch:** `feat/HLW-023-colorado-cascade`
+- **PR:** —
+- **Created:** 2026-08-23
+
+## Summary
+
+Extend the /water page up the Lower Colorado from the two lakes it shows today (Havasu,
+Mohave) to the **whole cascade**: Lake Powell → Glen Canyon Dam → Grand Canyon river →
+Lake Mead → Hoover Dam → (Mohave → Davis → Havasu → Parker). Plus **deep historical
+backfill** for the new points (like HLW-017 did for Havasu/Mohave).
+
+## Verified data sources (free, no key)
+
+USBR RISE items (fetch date-scoped to avoid the 90-yr hang; `accept: application/vnd.api+json`):
+
+| Reservoir | Elevation (ft) | Storage (af) | Total release (cfs) | Live sample |
+|---|---|---|---|---|
+| **Lake Powell** (Glen Canyon) | `508` | `509` | `4315` | 3,519 ft · 7,684 cfs |
+| **Lake Mead** (Hoover) | `6123` | `6124` | `6125` | 1,039 ft · 6.93M af · 4,871 cfs |
+
+USGS gages (waterservices.usgs.gov, param 00060 cfs) for the Grand Canyon reach:
+
+| Gage | Site | Live | Record from |
+|---|---|---|---|
+| Colorado R. **at Lees Ferry** (just below Glen Canyon Dam) | `09380000` | 7,970 cfs | 1921 |
+| Colorado R. **near Grand Canyon** | `09402500` | 7,530 cfs | ~1922 |
+| Colorado R. abv Diamond Creek nr Peach Springs | `09404200` | 8,350 cfs | recent |
+
+- **No RISE water temp** for Mead/Powell — omit temp for those two (Havasu/Mohave keep theirs).
+- Existing (unchanged): Havasu/Mohave elevation (USGS), storage/temp (RISE 6129/6134/6127/6132),
+  Davis release 6135, Parker release 6130.
+
+## Plan (phased)
+
+### Phase 1 — live data (`water.js` + ingest)
+- Add RISE consts: Mead 6123/6124/6125, Powell 508/509/4315; USGS Lees Ferry 09380000 (+ near
+  Grand Canyon 09402500 as the canyon reach).
+- `getLive()` fetches the new reservoirs + canyon flow (all soft-failing, date-scoped).
+- Restructure the response into a **cascade** (ordered Powell→Havasu) of `reservoirs` and
+  `reaches`, keeping back-compat fields (`lake`, `upstream`, `inflow`, `outflow`) for the
+  current home teaser.
+- `water-ingest.js`: extend the daily `WATER#DAILY` snapshot with `meadElevFt/meadStorageAf/
+  hooverCfs`, `powellElevFt/powellStorageAf/glenCanyonCfs`, `leesFerryCfs` (+ `grandCanyonCfs`).
+
+### Phase 2 — /water page redesign (the cascade view)
+- Present the system top→bottom as a **river cascade**: each reservoir a card (elevation,
+  storage acre-ft, % of full pool, low/normal/high vs history per HLW-018), each dam release /
+  river reach a flow row between them. Design direction chosen below.
+
+### Phase 3 — historical backfill (HLW-017-style)
+- RISE daily history for Mead (from ~1935) + Powell (from ~1963): storage, elevation, release.
+- USGS daily-values (dv) for the canyon gages (Lees Ferry from 1921).
+- Write into the existing `WATER#DAILY` rows (add the new fields per date); extend
+  `build-history-stats.mjs` so the new reservoirs get the same "vs history" context.
+
+## Open decision
+
+- **Page layout** for a now much taller page (3 lakes + 2 river reaches + Mohave/Havasu) —
+  see the design options in the chat.
+
+## Acceptance criteria
+
+- [ ] `/api/water` returns Mead + Powell + Grand Canyon reach (live), soft-failing.
+- [ ] Daily snapshots store the new fields; backfill loads decades of history.
+- [ ] /water shows the full cascade, each with vs-history context; 0 console errors.
+- [ ] Deploy: ingest + read Lambda + site (gated).
+
+## Notes
+
+- Big feature — phase it: live+ingest first, then page, then backfill. Backfill is large
+  (Mead ~33k days, Powell ~23k, canyon gages ~38k) but tiny/cheap in DynamoDB.

--- a/docs/issues/HLW-023-colorado-cascade.md
+++ b/docs/issues/HLW-023-colorado-cascade.md
@@ -1,6 +1,6 @@
 # HLW-023: Extend /water to the full Colorado cascade (Powell → Grand Canyon → Mead) + history
 
-- **Status:** proposed
+- **Status:** in-progress (layout: vertical river cascade)
 - **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/36
 - **Branch:** `feat/HLW-023-colorado-cascade`
 - **PR:** —
@@ -30,7 +30,10 @@ USGS gages (waterservices.usgs.gov, param 00060 cfs) for the Grand Canyon reach:
 | Colorado R. **near Grand Canyon** | `09402500` | 7,530 cfs | ~1922 |
 | Colorado R. abv Diamond Creek nr Peach Springs | `09404200` | 8,350 cfs | recent |
 
-- **No RISE water temp** for Mead/Powell — omit temp for those two (Havasu/Mohave keep theirs).
+- **Water temp availability (verified):** Havasu ✓ (RISE 6127), Mohave ✓ (RISE 6132),
+  **Grand Canyon / Lees Ferry ✓** (USGS 09380000 param 00010, ~69°F). **Mead ✗, Powell ✗** —
+  RISE has no reservoir water-temp for those two. So the reach gage = **Lees Ferry 09380000**
+  (gives flow *and* the cold below-the-dam temp); Mead/Powell show elevation + storage only.
 - Existing (unchanged): Havasu/Mohave elevation (USGS), storage/temp (RISE 6129/6134/6127/6132),
   Davis release 6135, Parker release 6130.
 

--- a/ingest/src/water-ingest.js
+++ b/ingest/src/water-ingest.js
@@ -18,6 +18,7 @@ const TABLE = process.env.TABLE_NAME;
 export const handler = async () => {
   const w = await getLive();
   const lake = w.lake || {}, up = w.upstream || {};
+  const c = Object.fromEntries((w.cascade || []).map((n) => [n.key, n])); // upstream cascade by key
   const date = new Date().toISOString().slice(0, 10); // UTC day; upsert keeps one/day
 
   const item = {
@@ -33,6 +34,14 @@ export const handler = async () => {
     mohaveTempF: up.waterTempF ?? null,
     davisCfs: w.inflow ? w.inflow.cfs : null,
     parkerCfs: w.outflow ? w.outflow.cfs : null,
+    // HLW-023 — upstream cascade (Powell / Grand Canyon / Mead / Hoover)
+    powellElevFt: c.powell ? c.powell.elevationFt : null,
+    powellStorageAf: c.powell ? c.powell.storageAf : null,
+    canyonCfs: c.grandcanyon ? c.grandcanyon.cfs : null,
+    canyonTempF: c.grandcanyon ? c.grandcanyon.waterTempF : null,
+    meadElevFt: c.mead ? c.mead.elevationFt : null,
+    meadStorageAf: c.mead ? c.mead.storageAf : null,
+    hooverCfs: c.hoover ? c.hoover.cfs : null,
   };
 
   // Skip writing an all-null snapshot (e.g. every upstream source hiccupped).

--- a/ingest/src/water.js
+++ b/ingest/src/water.js
@@ -41,6 +41,23 @@ const RISE_HAVASU_TEMP = process.env.RISE_HAVASU_TEMP || "6127"; // Lake Havasu 
 const RISE_MOHAVE_TEMP = process.env.RISE_MOHAVE_TEMP || "6132"; // Lake Mohave water temp (DegF)
 const RISE_HAVASU_STORAGE = process.env.RISE_HAVASU_STORAGE || "6129"; // Lake Havasu storage (acre-ft)
 const RISE_MOHAVE_STORAGE = process.env.RISE_MOHAVE_STORAGE || "6134"; // Lake Mohave storage (acre-ft)
+// HLW-023 — upstream cascade: Lake Powell (Glen Canyon) + Lake Mead (Hoover) via RISE, and the
+// Grand Canyon reach via USGS Lees Ferry (09380000 — flow 00060 + water temp 00010, cold below
+// the dam). One connector flow per reservoir gap. No RISE water-temp exists for Powell/Mead.
+const RISE_POWELL_ELEV = process.env.RISE_POWELL_ELEV || "508";
+const RISE_POWELL_STORAGE = process.env.RISE_POWELL_STORAGE || "509";
+const RISE_MEAD_ELEV = process.env.RISE_MEAD_ELEV || "6123";
+const RISE_MEAD_STORAGE = process.env.RISE_MEAD_STORAGE || "6124";
+const RISE_HOOVER_RELEASE = process.env.RISE_HOOVER_RELEASE || "6125";
+const USGS_GRANDCANYON = "09380000"; // Colorado R. at Lees Ferry, below Glen Canyon Dam
+// Full-pool reference (elevation ft / live-storage capacity acre-ft) for a coarse "% full".
+// Approximate published capacities — for the % readout only, not authoritative accounting.
+const POOL = {
+  powell: { fullElevFt: 3700, capacityAf: 24322000 },
+  mead:   { fullElevFt: 1229, capacityAf: 26120000 },
+  mohave: { fullElevFt: 647,  capacityAf: 1810000 },
+  havasu: { fullElevFt: 450,  capacityAf: 619000 },
+};
 
 const now = () => new Date().toISOString();
 
@@ -187,10 +204,44 @@ function warningsFor(lake, inflow, outflow) {
   return w;
 }
 
+// --- Colorado cascade (HLW-023): ordered Powell → Havasu ---
+function pctFull(storageAf, capacityAf) {
+  return storageAf != null && capacityAf ? Math.round((100 * storageAf) / capacityAf) : null;
+}
+function reservoirNode(key, name, dam, o) {
+  if (o.elevFt == null && o.storageAf == null) return null;
+  const pool = POOL[key] || {};
+  return {
+    type: "reservoir", key, name, dam,
+    elevationFt: o.elevFt ?? null, storageAf: o.storageAf ?? null,
+    fullElevFt: pool.fullElevFt ?? null, fullStorageAf: pool.capacityAf ?? null,
+    pctFull: pctFull(o.storageAf, pool.capacityAf),
+    waterTempF: o.tempF ?? null, star: !!o.star, observedAt: o.observedAt ?? null,
+  };
+}
+function flowNode(key, name, sub, o) {
+  if (o.cfs == null) return null;
+  return { type: "flow", key, name, sub, cfs: Math.round(o.cfs), trend: o.trend ?? null, context: o.context ?? null, waterTempF: o.tempF ?? null, observedAt: o.observedAt ?? null };
+}
+// Assemble the ordered cascade from primitive values, dropping any node we have no data for.
+function buildCascade(v) {
+  return [
+    reservoirNode("powell", "Lake Powell", "Glen Canyon Dam", { elevFt: v.powellElevFt, storageAf: v.powellStorageAf, observedAt: v.powellAt }),
+    flowNode("grandcanyon", "Grand Canyon", "below Glen Canyon Dam", { cfs: v.canyonCfs, tempF: v.canyonTempF, observedAt: v.canyonAt }),
+    reservoirNode("mead", "Lake Mead", "Hoover Dam", { elevFt: v.meadElevFt, storageAf: v.meadStorageAf, observedAt: v.meadAt }),
+    flowNode("hoover", "Hoover Dam", "into Lake Mohave", { cfs: v.hooverCfs, observedAt: v.hooverAt }),
+    reservoirNode("mohave", "Lake Mohave", "Davis Dam", { elevFt: v.mohaveElevFt, storageAf: v.mohaveStorageAf, tempF: v.mohaveTempF, observedAt: v.mohaveAt }),
+    flowNode("davis", "Davis Dam", "into Lake Havasu", { cfs: v.davisCfs, trend: v.davisTrend, context: v.davisCtx, observedAt: v.davisAt }),
+    reservoirNode("havasu", "Lake Havasu", "Parker Dam", { elevFt: v.havasuElevFt, storageAf: v.havasuStorageAf, tempF: v.havasuTempF, star: true, observedAt: v.havasuAt }),
+    flowNode("parker", "Parker Dam", "downstream to Parker", { cfs: v.parkerCfs, trend: v.parkerTrend, context: v.parkerCtx, observedAt: v.parkerAt }),
+  ].filter(Boolean);
+}
+
 export async function getLive() {
   const settle = async (p) => { try { return await p; } catch { return null; } };
   const month = new Date().getUTCMonth() + 1;
-  const [hav, moh, davisS, parkerS, havTemp, mohTemp, havStore, mohStore] = await Promise.all([
+  const [hav, moh, davisS, parkerS, havTemp, mohTemp, havStore, mohStore,
+         pElev, pStore, mElev, mStore, hoov, canyonF, canyonT] = await Promise.all([
     settle(usgsLatest("iv", "09427500", "00065", 8000)),  // Lake Havasu gage height
     settle(usgsLatest("dv", "09422500", "62614", 8000)),  // Lake Mohave elevation (NGVD29)
     settle(riseSeries(RISE_DAVIS_ID, 30)),                 // Davis release (current + chart)
@@ -199,6 +250,13 @@ export async function getLive() {
     settle(riseNum(RISE_MOHAVE_TEMP)),
     settle(riseNum(RISE_HAVASU_STORAGE)),                  // acre-ft
     settle(riseNum(RISE_MOHAVE_STORAGE)),                  // acre-ft
+    settle(riseNum(RISE_POWELL_ELEV)),                     // Lake Powell elevation (ft)
+    settle(riseNum(RISE_POWELL_STORAGE)),                  // Lake Powell storage (af)
+    settle(riseNum(RISE_MEAD_ELEV)),                       // Lake Mead elevation (ft)
+    settle(riseNum(RISE_MEAD_STORAGE)),                    // Lake Mead storage (af)
+    settle(riseNum(RISE_HOOVER_RELEASE)),                  // Hoover Dam release (cfs)
+    settle(usgsLatest("iv", USGS_GRANDCANYON, "00060", 8000)), // Grand Canyon flow (cfs)
+    settle(usgsLatest("iv", USGS_GRANDCANYON, "00010", 8000)), // Grand Canyon water temp (°C)
   ]);
   const elev = hav ? +(hav.value + HAVASU_DATUM).toFixed(2) : null;
   const lake = hav ? {
@@ -214,9 +272,19 @@ export async function getLive() {
   } : null;
   const inflow = seriesToRelease(davisS, "Davis Dam release", NORMALS.davisRelease, month);
   const outflow = seriesToRelease(parkerS, "Parker Dam release", NORMALS.parkerRelease, month);
+  const cascade = buildCascade({
+    powellElevFt: pElev ? +pElev.value.toFixed(2) : null, powellStorageAf: pStore ? Math.round(pStore.value) : null, powellAt: (pElev || pStore || {}).at,
+    canyonCfs: canyonF ? canyonF.value : null, canyonTempF: canyonT ? +(canyonT.value * 9 / 5 + 32).toFixed(1) : null, canyonAt: (canyonF || {}).at,
+    meadElevFt: mElev ? +mElev.value.toFixed(2) : null, meadStorageAf: mStore ? Math.round(mStore.value) : null, meadAt: (mElev || mStore || {}).at,
+    hooverCfs: hoov ? hoov.value : null, hooverAt: (hoov || {}).at,
+    mohaveElevFt: upstream ? upstream.elevationFt : null, mohaveStorageAf: upstream ? upstream.storageAf : null, mohaveTempF: upstream ? upstream.waterTempF : null, mohaveAt: upstream ? upstream.observedAt : null,
+    davisCfs: inflow ? inflow.cfs : null, davisTrend: inflow ? inflow.trend : null, davisCtx: inflow ? inflow.context : null, davisAt: inflow ? inflow.observedAt : null,
+    havasuElevFt: lake ? lake.elevationFt : null, havasuStorageAf: lake ? lake.storageAf : null, havasuTempF: lake ? lake.waterTempF : null, havasuAt: lake ? lake.observedAt : null,
+    parkerCfs: outflow ? outflow.cfs : null, parkerTrend: outflow ? outflow.trend : null, parkerCtx: outflow ? outflow.context : null, parkerAt: outflow ? outflow.observedAt : null,
+  });
   const notes = [];
   if (!inflow && !outflow) notes.push("Dam release rates (USBR) coming soon.");
-  return { source: "live", lake, upstream, inflow, outflow, series: buildSeries(davisS, parkerS), warnings: warningsFor(lake, inflow, outflow), notes };
+  return { source: "live", lake, upstream, inflow, outflow, cascade, series: buildSeries(davisS, parkerS), warnings: warningsFor(lake, inflow, outflow), notes };
 }
 
 // Read the latest stored snapshot (+ recent series) from DynamoDB — populated by the
@@ -256,7 +324,17 @@ function snapshotsToResponse(items) {
   const parkerSeries = asc.filter((s) => s.parkerCfs != null).map((s) => ({ date: s.date, value: s.parkerCfs }));
   const inflow = seriesToRelease(davisSeries, "Davis Dam release", NORMALS.davisRelease, month);
   const outflow = seriesToRelease(parkerSeries, "Parker Dam release", NORMALS.parkerRelease, month);
-  return { source: "stored", lake, upstream, inflow, outflow, series: buildSeries(davisSeries, parkerSeries), warnings: warningsFor(lake, inflow, outflow), notes: [] };
+  const cascade = buildCascade({
+    powellElevFt: latest.powellElevFt ?? null, powellStorageAf: latest.powellStorageAf ?? null, powellAt: latest.date,
+    canyonCfs: latest.canyonCfs ?? null, canyonTempF: latest.canyonTempF ?? null, canyonAt: latest.date,
+    meadElevFt: latest.meadElevFt ?? null, meadStorageAf: latest.meadStorageAf ?? null, meadAt: latest.date,
+    hooverCfs: latest.hooverCfs ?? null, hooverAt: latest.date,
+    mohaveElevFt: latest.mohaveElevFt ?? null, mohaveStorageAf: latest.mohaveStorageAf ?? null, mohaveTempF: latest.mohaveTempF ?? null, mohaveAt: latest.date,
+    davisCfs: inflow ? inflow.cfs : latest.davisCfs, davisTrend: inflow ? inflow.trend : null, davisCtx: inflow ? inflow.context : null, davisAt: latest.date,
+    havasuElevFt: latest.havasuElevFt ?? null, havasuStorageAf: latest.havasuStorageAf ?? null, havasuTempF: latest.havasuTempF ?? null, havasuAt: latest.date,
+    parkerCfs: outflow ? outflow.cfs : latest.parkerCfs, parkerTrend: outflow ? outflow.trend : null, parkerCtx: outflow ? outflow.context : null, parkerAt: latest.date,
+  });
+  return { source: "stored", lake, upstream, inflow, outflow, cascade, series: buildSeries(davisSeries, parkerSeries), warnings: warningsFor(lake, inflow, outflow), notes: [] };
 }
 
 export async function getWater(mock) {
@@ -296,11 +374,23 @@ function mockSeries(dCur, pCur) {
   }
   return { dates, davisIn, parkerOut };
 }
+function mockCascade(lake, upstream, dCfs, pCfs) {
+  return buildCascade({
+    powellElevFt: 3519, powellStorageAf: 5203670, powellAt: now(),
+    canyonCfs: 7970, canyonTempF: 69.4, canyonAt: now(),
+    meadElevFt: 1039.3, meadStorageAf: 6930260, meadAt: now(),
+    hooverCfs: 4871, hooverAt: now(),
+    mohaveElevFt: upstream.elevationFt, mohaveStorageAf: upstream.storageAf, mohaveTempF: upstream.waterTempF, mohaveAt: now(),
+    davisCfs: dCfs, davisAt: now(),
+    havasuElevFt: lake.elevationFt, havasuStorageAf: lake.storageAf, havasuTempF: lake.waterTempF, havasuAt: now(),
+    parkerCfs: pCfs, parkerAt: now(),
+  });
+}
 function mockScenario(lake, upstream, dCfs, dTrend, pCfs, pTrend) {
   const m = new Date().getUTCMonth() + 1;
   const inflow = { name: "Davis Dam release", cfs: dCfs, trend: dTrend, observedAt: now().slice(0, 10), source: "USBR RISE", context: contextFor(NORMALS.davisRelease, dCfs, m) };
   const outflow = { name: "Parker Dam release", cfs: pCfs, trend: pTrend, observedAt: now().slice(0, 10), source: "USBR RISE", context: contextFor(NORMALS.parkerRelease, pCfs, m) };
-  return { lake, upstream, inflow, outflow, series: mockSeries(dCfs, pCfs), warnings: warningsFor(lake, inflow, outflow), notes: [] };
+  return { lake, upstream, inflow, outflow, cascade: mockCascade(lake, upstream, dCfs, pCfs), series: mockSeries(dCfs, pCfs), warnings: warningsFor(lake, inflow, outflow), notes: [] };
 }
 
 const MOCK = {

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,5 +1,5 @@
 /* Havasu Lake Weather — service worker (installability + offline shell) */
-const CACHE = "havasu-wx-v19";
+const CACHE = "havasu-wx-v21";
 const SHELL = [
   "/", "/index.html", "/water.html", "/manifest.json", "/sw-register.js",
   "/assets/icon-192.png", "/assets/icon-512.png", "/assets/icon-180.png",

--- a/web/water.html
+++ b/web/water.html
@@ -128,6 +128,34 @@
   .lg::before{content:"";width:12px;height:3px;border-radius:2px;}
   .lg-in::before{background:#2fb9c4;} .lg-out::before{background:#ff7a4d;}
   #flowChart{width:100%;height:130px;display:block;}
+  /* ---- Colorado cascade (HLW-023) ---- */
+  .cascade{display:flex;flex-direction:column;}
+  .casc-res{position:relative;display:flex;background:var(--glass);border:1px solid var(--brd);border-radius:var(--radius);padding:14px 16px 14px 18px;overflow:hidden;box-shadow:var(--shadow);}
+  .casc-res.star{border-color:rgba(127,230,226,.55);box-shadow:0 0 0 1px rgba(127,230,226,.22),var(--shadow);}
+  .casc-fill-bg{position:absolute;left:0;top:0;bottom:0;width:6px;background:rgba(255,255,255,.1);}
+  .casc-fill{position:absolute;left:0;bottom:0;width:6px;background:linear-gradient(180deg,#7fe6e2,#2fb9c4);}
+  .casc-fill.low{background:linear-gradient(180deg,#ffbf5c,#ff7a4d);}
+  .casc-body{flex:1;min-width:0;}
+  .casc-name{font-weight:800;font-size:1.06rem;display:flex;align-items:center;gap:7px;}
+  .casc-name .ico{font-size:1.05rem;}
+  .casc-dam{font-size:.66rem;font-weight:700;color:var(--ink-faint);text-transform:uppercase;letter-spacing:.05em;margin-top:1px;}
+  .casc-nums{display:flex;align-items:baseline;gap:13px;margin-top:7px;flex-wrap:wrap;}
+  .casc-pct{font-weight:800;font-size:1.55rem;line-height:1;color:var(--teal-deep);font-variant-numeric:tabular-nums;}
+  .casc-pct.low{color:var(--coral-deep);}
+  .casc-pct small{font-size:.66rem;font-weight:700;color:var(--ink-soft);}
+  .casc-elev{font-weight:700;font-size:.95rem;color:var(--ink-soft);font-variant-numeric:tabular-nums;}
+  .casc-meta{font-size:.78rem;font-weight:600;color:var(--ink-faint);margin-top:4px;}
+  .casc-meta b{color:var(--ink-soft);font-weight:800;}
+  .casc-flow{display:flex;flex-direction:column;align-items:center;}
+  .casc-flow .line{width:2px;height:11px;background:linear-gradient(180deg,rgba(127,230,226,.45),rgba(47,185,196,.55));}
+  .casc-flow .pill{display:flex;align-items:center;gap:9px;background:var(--glass-2);border:1px solid var(--brd);border-radius:999px;padding:5px 13px;font-size:.8rem;margin:1px 0;}
+  .casc-flow .pill .fn{color:var(--ink-faint);font-weight:700;}
+  .casc-flow .pill .fv{font-weight:800;font-variant-numeric:tabular-nums;}
+  .casc-flow .pill .ft{color:var(--teal-deep);font-weight:700;font-size:.74rem;}
+  .casc-flow .pill .cc{font-size:.64rem;font-weight:800;text-transform:uppercase;letter-spacing:.03em;padding:1px 7px;border-radius:999px;}
+  .cc.chip-low{background:rgba(255,191,92,.22);color:var(--gold);} .cc.chip-normal{background:rgba(47,185,196,.2);color:var(--teal-deep);} .cc.chip-high{background:rgba(255,122,77,.24);color:var(--coral-deep);}
+  .casc-intro{font-size:.84rem;font-weight:650;color:var(--ink-soft);line-height:1.4;margin:2px 2px 4px;}
+  .casc-note{font-size:.72rem;font-weight:600;color:var(--ink-faint);text-align:center;margin-top:2px;}
   @media (min-width:560px){ .lbl .cfs{font-size:1.5rem;} }
 </style>
 </head>
@@ -157,43 +185,22 @@
 
   <main class="wpage">
     <div id="warnings"></div>
-    <section class="card">
-      <h2>Lake Havasu <span class="src" id="lakeSrc"></span></h2>
-      <div class="lk-elev-label">Surface elevation</div>
-      <div style="display:flex;align-items:center;gap:10px;flex-wrap:wrap;">
-        <div class="lk-elev"><span id="lakeElev">--</span><small> ft</small></div>
-        <span class="pill pill-full" id="lakePill">&mdash;</span>
-      </div>
-      <div class="lk-elev-note">height of the water above sea level &mdash; <b>not depth</b> (full pool &asymp; 450 ft)</div>
-      <div class="metrics">
-        <div class="metric"><div class="k">Storage (volume)</div><div class="v"><span id="lakeStorage">--</span><small> acre-ft</small></div></div>
-        <div class="metric"><div class="k">Water temp</div><div class="v"><span id="lakeTemp">--</span><small>&deg;F</small></div></div>
-      </div>
-      <div class="lk-history" id="lakeHistory" hidden>
+    <div class="casc-intro">The Colorado, top to bottom — every drop that reaches Lake Havasu passes through these first.</div>
+    <div id="cascade" class="cascade" aria-label="Colorado River — Lake Powell down to Lake Havasu"></div>
+
+    <section class="card" id="histCard" hidden>
+      <h2>Lake Havasu · vs history <span class="src">USBR RISE</span></h2>
+      <div class="lk-history" id="lakeHistory">
         <div class="lk-hist-txt" id="lakeHistTxt"></div>
         <svg class="lk-spark" id="lakeSpark" viewBox="0 0 300 46" preserveAspectRatio="none" role="img" aria-label="Lake Havasu storage by year"></svg>
         <div class="lk-spark-cap" id="lakeSparkCap"></div>
       </div>
     </section>
 
-    <section class="card">
-      <h2>Dam releases <span class="src">USBR RISE · daily</span></h2>
-      <div id="flowRows"></div>
-      <div class="flow-net" id="flowNetRow"></div>
-    </section>
-
     <section class="card" id="chartCard" hidden>
       <h2>Recent flow <span class="src">last 30 days · cfs</span></h2>
       <div class="chart-legend"><span class="lg lg-in">Davis in</span><span class="lg lg-out">Parker out</span></div>
       <svg id="flowChart" viewBox="0 0 320 130" preserveAspectRatio="none" role="img" aria-label="Recent dam releases"></svg>
-    </section>
-
-    <section class="card">
-      <h2>Lake Mohave <span class="src">upstream</span></h2>
-      <div class="metrics">
-        <div class="metric"><div class="k">Surface elev</div><div class="v"><span id="mohElev">--</span><small> ft</small></div></div>
-        <div class="metric"><div class="k">Water temp</div><div class="v"><span id="mohTemp">--</span><small>&deg;F</small></div></div>
-      </div>
     </section>
 
     <div id="notes"></div>
@@ -234,10 +241,43 @@
   }
   function ordinal(n){var s=["th","st","nd","rd"],v=n%100;return n+(s[(v-20)%10]||s[v]||s[0]);}
   // "vs history" callout + decades sparkline (HLW-018)
+  // ---- Colorado cascade (HLW-023) ----
+  var CASC_ICON={powell:"🏔️",mead:"🏞️",mohave:"🏞️",havasu:"⭐"};
+  function resHTML(n){
+    var pf=n.pctFull, low=pf!=null&&pf<40;
+    var meta=[];
+    if(n.storageAf!=null)meta.push('<b>'+fmt(n.storageAf)+'</b> acre-ft');
+    if(n.waterTempF!=null)meta.push('<b>'+n.waterTempF.toFixed(1)+'°F</b> water');
+    var pct=pf!=null?'<span class="casc-pct'+(low?" low":"")+'">'+pf+'<small>% full</small></span>':'';
+    var elev=n.elevationFt!=null?'<span class="casc-elev">'+fmt(n.elevationFt)+' ft</span>':'';
+    return '<div class="casc-res'+(n.star?" star":"")+'">'+
+      '<div class="casc-fill-bg"></div><div class="casc-fill'+(low?" low":"")+'" style="height:'+(pf!=null?Math.max(3,Math.min(100,pf)):0)+'%"></div>'+
+      '<div class="casc-body">'+
+        '<div class="casc-name"><span class="ico">'+(CASC_ICON[n.key]||"🏞️")+'</span>'+esc(n.name)+'</div>'+
+        '<div class="casc-dam">'+esc(n.dam)+'</div>'+
+        '<div class="casc-nums">'+pct+elev+'</div>'+
+        (meta.length?'<div class="casc-meta">'+meta.join(" · ")+'</div>':'')+
+      '</div></div>';
+  }
+  function flowHTML(n){
+    var arrow=n.trend==="rising"?" ▲":n.trend==="falling"?" ▼":"";
+    var lvl=n.context&&n.context.level;
+    var chip=(lvl&&lvl!=="unknown")?'<span class="cc chip-'+lvl+'">'+lvl+'</span>':"";
+    var temp=n.waterTempF!=null?'<span class="ft">'+Math.round(n.waterTempF)+'°F</span>':"";
+    var sub=n.sub?' · '+esc(n.sub):"";
+    return '<div class="casc-flow"><div class="line"></div>'+
+      '<div class="pill"><span class="fn">'+esc(n.name)+sub+'</span><span class="fv">'+fmt(n.cfs)+' cfs'+arrow+'</span>'+temp+chip+'</div>'+
+      '<div class="line"></div></div>';
+  }
+  function renderCascade(c){
+    var host=$("cascade"); if(!host)return;
+    host.innerHTML=(c||[]).map(function(n){return n.type==="reservoir"?resHTML(n):flowHTML(n);}).join("");
+  }
+
   function renderHistory(h){
-    var box=$("lakeHistory");
-    if(!h||h.percentile==null||!h.sparkline||h.sparkline.length<3){box.hidden=true;return;}
-    box.hidden=false;
+    var box=$("histCard");
+    if(!h||h.percentile==null||!h.sparkline||h.sparkline.length<3){if(box)box.hidden=true;return;}
+    if(box)box.hidden=false;
     var p=h.percentile, mo=h.monthName||MONTHS[new Date().getUTCMonth()+1], cls,ico,txt;
     if(p<=25){cls="lo";ico="📉";txt="Lower than "+(100-p)+"% of past "+mo+"s";}
     else if(p>=75){cls="hi";ico="📈";txt="Higher than "+p+"% of past "+mo+"s";}
@@ -287,35 +327,16 @@
   }
   function render(d){
     if(!d)return;
-    var lake=d.lake||{}, up=d.upstream||{}, inf=d.inflow, out=d.outflow;
-    $("lakeSrc").textContent=d.source==="mock"?"demo data":"USGS";
-    $("lakeElev").textContent=lake.elevationFt!=null?lake.elevationFt.toFixed(1):"--";
-    var st=lake.status||"unknown";
-    var pill=$("lakePill");
-    pill.className="pill pill-"+(st==="low"?"low":st==="unknown"?"normal":st);
-    pill.textContent={full:"Full pool",normal:"Normal",low:"Low",unknown:"—"}[st]||"—";
-    $("lakeTemp").textContent=lake.waterTempF!=null?lake.waterTempF.toFixed(1):"--";
-    $("lakeStorage").textContent=lake.storageAf!=null?fmt(lake.storageAf):"--";
-    renderHistory(lake.history);
-    $("mohElev").textContent=up.elevationFt!=null?up.elevationFt.toFixed(1):"--";
-    $("mohTemp").textContent=up.waterTempF!=null?up.waterTempF.toFixed(1):"--";
-
-    var inCfs=inf&&inf.cfs!=null?inf.cfs:null, outCfs=out&&out.cfs!=null?out.cfs:null;
-    if($("inCfs"))$("inCfs").textContent=fmt(inCfs);   // hidden animation-hero labels
-    if($("outCfs"))$("outCfs").textContent=fmt(outCfs);
-
     renderWarnings(d.warnings||[]);
-    $("flowRows").innerHTML=flowRow("Davis Dam in",inf)+flowRow("Parker Dam out",out);
-    if(inCfs!=null&&outCfs!=null){
-      var net=inCfs-outCfs;
-      $("flowNetRow").innerHTML='<span class="net-dot" style="background:'+(net>=0?"#7fe6e2":"#ff7a4d")+'"></span><span>'+(net>=0?"Filling":"Draining")+' <b>'+(net>=0?"+":"")+fmt(net)+' cfs</b></span> <span class="net-sub">(inflow − outflow)</span>';
-      if($("netTxt"))$("netTxt").innerHTML=(net>=0?"Filling ":"Draining ")+"<b>"+(net>=0?"+":"")+fmt(net)+" cfs</b>";
-    }else{ $("flowNetRow").innerHTML='<span class="net-sub">Dam release data pending (USBR).</span>'; }
+    renderCascade(d.cascade||[]);
+    renderHistory(d.lake&&d.lake.history);
     renderChart(d.series);
-
     $("notes").innerHTML=(d.notes||[]).map(function(n){return '<div class="note">'+esc(n)+'</div>';}).join("");
-
-    // drive the animation (fall back to a gentle flow if releases are pending)
+    // hidden flow-hero fallback (animation markup kept for a later pass)
+    var c={};(d.cascade||[]).forEach(function(n){c[n.key]=n;});
+    var inCfs=c.davis?c.davis.cfs:null, outCfs=c.parker?c.parker.cfs:null;
+    if($("inCfs"))$("inCfs").textContent=fmt(inCfs);
+    if($("outCfs"))$("outCfs").textContent=fmt(outCfs);
     setFlow(inCfs!=null?inCfs:11000, outCfs!=null?outCfs:9000);
   }
 


### PR DESCRIPTION
Part of #36. Extends /water from 2 lakes to the full Lower Colorado cascade. **Phase 1 (data) + Phase 2 (page)**; historical backfill (Phase 3) follows.

## Data (`water.js`, verified live, free/no-key)
- **Lake Powell** (Glen Canyon): RISE elev 508 / storage 509 → 3,519 ft, 21% full
- **Grand Canyon** reach: USGS Lees Ferry 09380000 (flow 00060 + water temp 00010) → 7,970 cfs, 69°F
- **Lake Mead** (Hoover): RISE elev 6123 / storage 6124 / release 6125 → 1,039 ft, 27% full
- Existing Mohave/Havasu/Davis/Parker unchanged
- New ordered `cascade` array (Powell→Havasu) of reservoir/flow nodes with %-full, in both live + stored paths; mock cascade for `?mockWater=`. Mead/Powell have no water temp (RISE); shown for canyon/Mohave/Havasu.
- `water-ingest.js` snapshots the new fields (Powell/Mead/canyon).

## Page (`water.html`)
Rebuilt as a **vertical river cascade**: fill-bar reservoir cards + connector flow pills, top→bottom, starred Havasu; Havasu vs-history sparkline + 30-day chart kept below. SW → v21.

## Verified
Live `getLive()` returns all 8 nodes with correct magnitudes; `/water?mockWater=normal` renders the full cascade, 0 console errors (Playwright).

## Deploy
Ingest (read Lambda + water-ingest) + site. I'll trigger one ingest run post-deploy so the stored snapshots gain the upstream fields and `/api/water` serves the full cascade.

## Not in this PR
Phase 3 historical backfill (Mead ~1935, Powell ~1963, Lees Ferry from 1921) + vs-history for the new reservoirs — next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)