### PR TITLE
fix(HLW-023): remove dangling connector below Parker Dam flow

### DIFF
--- a/web/sw.js
+++ b/web/sw.js
@@ -1,5 +1,5 @@
 /* Havasu Lake Weather — service worker (installability + offline shell) */
-const CACHE = "havasu-wx-v22";
+const CACHE = "havasu-wx-v23";
 const SHELL = [
   "/", "/index.html", "/water.html", "/manifest.json", "/sw-register.js",
   "/assets/icon-192.png", "/assets/icon-512.png", "/assets/icon-180.png",

--- a/web/water.html
+++ b/web/water.html
@@ -155,6 +155,7 @@
   .casc-hist .yrs{font-weight:600;color:var(--ink-faint);font-size:.68rem;}
   .casc-flow{display:flex;flex-direction:column;align-items:center;}
   .casc-flow .line{width:2px;height:11px;background:linear-gradient(180deg,rgba(127,230,226,.45),rgba(47,185,196,.55));}
+  #cascade .casc-flow:last-child .line:last-child{display:none;} /* no trailing connector below the final (Parker) flow */
   .casc-flow .pill{display:flex;align-items:center;gap:9px;background:var(--glass-2);border:1px solid var(--brd);border-radius:999px;padding:5px 13px;font-size:.8rem;margin:1px 0;}
   .casc-flow .pill .fn{color:var(--ink-faint);font-weight:700;}
   .casc-flow .pill .fv{font-weight:800;font-variant-numeric:tabular-nums;}


### PR DESCRIPTION
Small visual fix: the final Parker Dam flow pill had a vertical connector line dangling below it to nothing. One CSS rule hides the trailing `.line` on the last `.casc-flow` only. Verified: Parker's bottom line hidden, top line + all middle connectors intact, 0 console errors. Site-only. SW v23.