### PR TITLE
HLW-021: deploy the sunrise/sunset sun-arc

### DIFF
--- a/docs/issues/HLW-021-sun-arc.md
+++ b/docs/issues/HLW-021-sun-arc.md
@@ -1,0 +1,43 @@
+# HLW-021: Sunrise & sunset (live sun-arc, client-side)
+
+- **Status:** in-progress (approved: sun-arc strip)
+- **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/34
+- **Branch:** `feat/HLW-021-sun-arc`
+- **PR:** (opened from this branch)
+- **Created:** 2026-08-23
+
+## Summary
+
+Show today's **sunrise and sunset** with a sun-arc: an arc from sunrise to sunset, a dot at
+the sun's current position, times at each end, and daylight length. Live only, no history.
+
+## Approach — no backend
+
+Sunrise/sunset are a pure function of lat/lon + date, and the page already carries our exact
+coordinates (34.4822, −114.4138). Compute them **client-side** with the standard NOAA/SunCalc
+solar formula (~30 lines) — instant, exact for Havasu Lake, works offline in the PWA, no API,
+no Lambda, no external dependency. Refreshes daily; the position dot updates each minute.
+
+- Times displayed in **Havasu Lake local time** (America/Los_Angeles) regardless of the
+  viewer's timezone (`toLocaleTimeString` with an explicit `timeZone`). The current-position
+  fraction compares absolute instants, so it's timezone-independent.
+- **Site-only** change: `web/index.html` (+ SW bump). No read-Lambda deploy.
+
+## Plan
+
+- Add a `.sun-arc` glass panel after the tiles row: an SVG arc (quadratic curve) with a
+  warm dawn→noon→dusk gradient, a sun dot positioned along the arc by the day's elapsed
+  fraction, a horizon line, and sunrise/sunset times at the ends + "Hh Mm of daylight".
+- Night (before sunrise / after sunset): dim the arc, park the dot at the horizon.
+- JS: `sunEvents(date, lat, lng)` (SunCalc algorithm) + `renderSun()` on load + every minute.
+
+## Acceptance criteria
+
+- [ ] Sun-arc shows correct sunrise/sunset for Havasu Lake in Pacific time.
+- [ ] Dot sits at the right spot for the current time; night state handled.
+- [ ] No backend/API/external dependency; 0 console errors; theme-consistent.
+- [ ] Deploy: site only (gated).
+
+## Out of scope
+
+- Sunrise/sunset for future days, golden-hour, moon phase (live-only per request).

--- a/web/index.html
+++ b/web/index.html
@@ -162,6 +162,18 @@
   .tile-val{font-size:1.7rem;font-weight:800;line-height:1;letter-spacing:-.5px;}
   .tile-val small{font-size:.9rem;font-weight:700;color:var(--ink-soft);}
   .tile-sub{font-size:.8rem;font-weight:650;color:var(--ink-soft);}
+  /* ---- sunrise/sunset sun-arc (HLW-021) ---- */
+  .sun-arc{padding:14px 16px 12px;}
+  .sun-arc-top{display:flex;align-items:center;justify-content:space-between;gap:10px;}
+  .sun-arc-top .t{font-size:.72rem;font-weight:800;letter-spacing:.6px;text-transform:uppercase;color:var(--ink-soft);display:flex;align-items:center;gap:8px;}
+  .sun-arc-top .t .ico{width:22px;height:22px;flex:none;color:var(--coral-deep);}
+  .sun-daylight{font-size:.74rem;font-weight:750;color:var(--ink-soft);}
+  .sun-svg{width:100%;height:92px;display:block;overflow:visible;margin-top:6px;}
+  .sun-ends{display:flex;justify-content:space-between;align-items:flex-end;margin-top:4px;}
+  .sun-end .lbl{font-size:.62rem;font-weight:800;letter-spacing:.05em;text-transform:uppercase;color:var(--ink-faint);}
+  .sun-end .val{font-size:1rem;font-weight:800;font-variant-numeric:tabular-nums;}
+  .sun-end.set{text-align:right;}
+  .sun-arc.night .sun-svg{opacity:.5;}
   .chip{display:inline-block;padding:2px 9px;border-radius:999px;font-size:.68rem;font-weight:800;letter-spacing:.4px;text-transform:uppercase;}
   .chip.veryhigh{background:rgba(232,69,31,.16);color:var(--coral-deep);}
   .chip.falling{background:rgba(15,127,143,.16);color:var(--teal-deep);}
@@ -467,6 +479,29 @@
         <div class="tile-top"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 3v18M7 6h5M7 11h4M7 16h5"/><path d="M17 3v18"/></svg><span class="t">24h Range</span></div>
         <div class="tile-val"><span id="hi">--</span>&deg; <small>/ <span id="lo">--</span>&deg;F</small></div>
         <div class="tile-sub">High &middot; Low</div>
+      </div>
+    </section>
+
+    <!-- SUN — sunrise/sunset arc, computed client-side (HLW-021) -->
+    <section class="glass sun-arc" id="sunArc" aria-label="Sunrise and sunset">
+      <div class="sun-arc-top">
+        <span class="t"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M2 12h2M20 12h2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M19.1 4.9l-1.4 1.4M6.3 17.7l-1.4 1.4"/></svg>Sun</span>
+        <span class="sun-daylight" id="sunDaylight"></span>
+      </div>
+      <svg class="sun-svg" viewBox="0 0 300 92" preserveAspectRatio="xMidYMax meet" role="img" aria-label="Sun path from sunrise to sunset">
+        <defs>
+          <linearGradient id="sunArcGrad" x1="0" y1="0" x2="1" y2="0">
+            <stop offset="0" stop-color="#ff9a5a"/><stop offset=".5" stop-color="#ffcf5c"/><stop offset="1" stop-color="#ff8f68"/>
+          </linearGradient>
+        </defs>
+        <line x1="12" y1="78" x2="288" y2="78" stroke="rgba(120,70,40,.28)" stroke-width="1.5"/>
+        <path d="M24 78 Q150 -58 276 78" fill="none" stroke="url(#sunArcGrad)" stroke-width="2.6" stroke-linecap="round" stroke-dasharray="2 5" opacity=".8"/>
+        <circle id="sunDotHalo" cx="24" cy="78" r="13" fill="rgba(255,196,74,.35)"/>
+        <circle id="sunDot" cx="24" cy="78" r="6.5" fill="#ffd24a" stroke="#fff6d8" stroke-width="1.5"/>
+      </svg>
+      <div class="sun-ends">
+        <div class="sun-end rise"><div class="lbl">🌅 Sunrise</div><div class="val" id="sunriseT">--</div></div>
+        <div class="sun-end set"><div class="lbl">Sunset 🌇</div><div class="val" id="sunsetT">--</div></div>
       </div>
     </section>
 
@@ -871,6 +906,52 @@
     document.getElementById("iosX").addEventListener("click",function(){callout.hidden=true;remember();});
     callout.hidden=false;
   }
+})();
+</script>
+<script>
+/* Sunrise/sunset sun-arc (HLW-021) — computed client-side (SunCalc algorithm), no API.
+   Times shown in Havasu Lake local time regardless of the viewer's timezone. */
+(function(){
+  var LAT=34.4822, LNG=-114.4138, TZ="America/Los_Angeles";
+  var $=function(id){return document.getElementById(id);};
+  var rad=Math.PI/180, dayMs=86400000, J1970=2440588, J2000=2451545, E=rad*23.4397, J0=0.0009;
+  function toDays(d){return d.valueOf()/dayMs-0.5+J1970-J2000;}
+  function meanAnomaly(d){return rad*(357.5291+0.98560028*d);}
+  function eclipticLng(M){var C=rad*(1.9148*Math.sin(M)+0.02*Math.sin(2*M)+0.0003*Math.sin(3*M));return M+C+rad*102.9372+Math.PI;}
+  function declination(L){return Math.asin(Math.sin(L)*Math.sin(E));}
+  function transit(Ht,lw,n){return J0+(Ht+lw)/(2*Math.PI)+n;}
+  function solarTransitJ(ds,M,L){return J2000+ds+0.0053*Math.sin(M)-0.0069*Math.sin(2*L);}
+  function hourAngle(h,phi,d){var x=(Math.sin(h)-Math.sin(phi)*Math.sin(d))/(Math.cos(phi)*Math.cos(d));return Math.acos(Math.max(-1,Math.min(1,x)));}
+  function sunEvents(date){
+    var lw=rad*-LNG, phi=rad*LAT, d=toDays(date);
+    var n=Math.round(d-J0-lw/(2*Math.PI));
+    var ds=transit(0,lw,n), M=meanAnomaly(ds), L=eclipticLng(M), dec=declination(L);
+    var Jnoon=solarTransitJ(ds,M,L);
+    var w=hourAngle(rad*-0.833,phi,dec);
+    var Jset=solarTransitJ(transit(w,lw,n),M,L), Jrise=Jnoon-(Jset-Jnoon);
+    var fromJ=function(j){return new Date((j+0.5-J1970)*dayMs);};
+    return {sunrise:fromJ(Jrise), sunset:fromJ(Jset)};
+  }
+  function fmt(d){return d.toLocaleTimeString("en-US",{timeZone:TZ,hour:"numeric",minute:"2-digit"});}
+  function bez(t,p0,p1,p2){var u=1-t;return u*u*p0+2*u*t*p1+t*t*p2;}
+  function render(){
+    var card=$("sunArc"); if(!card) return;
+    var now=new Date(), s=sunEvents(now), rise=s.sunrise, set=s.sunset;
+    if(isNaN(rise.valueOf())||isNaN(set.valueOf())){card.hidden=true;return;}
+    $("sunriseT").textContent=fmt(rise);
+    $("sunsetT").textContent=fmt(set);
+    var mins=Math.max(0,Math.round((set-rise)/60000));
+    $("sunDaylight").textContent=Math.floor(mins/60)+"h "+(mins%60)+"m of daylight";
+    var frac=(now-rise)/(set-rise), day=frac>=0&&frac<=1, tc=Math.max(0,Math.min(1,frac));
+    var x=bez(tc,24,150,276), y=bez(tc,78,-58,78);
+    var dot=$("sunDot"), halo=$("sunDotHalo");
+    dot.setAttribute("cx",x.toFixed(1)); dot.setAttribute("cy",y.toFixed(1));
+    halo.setAttribute("cx",x.toFixed(1)); halo.setAttribute("cy",y.toFixed(1));
+    dot.setAttribute("fill",day?"#ffd24a":"#cfe0ff");
+    halo.setAttribute("fill",day?"rgba(255,196,74,.35)":"rgba(180,205,255,.28)");
+    card.classList.toggle("night",!day);
+  }
+  render(); setInterval(render,60000);
 })();
 </script>
 <script src="/sw-register.js" defer></script>

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,5 +1,5 @@
 /* Havasu Lake Weather — service worker (installability + offline shell) */
-const CACHE = "havasu-wx-v19";
+const CACHE = "havasu-wx-v20";
 const SHELL = [
   "/", "/index.html", "/water.html", "/manifest.json", "/sw-register.js",
   "/assets/icon-192.png", "/assets/icon-512.png", "/assets/icon-180.png",


### PR DESCRIPTION
Deploys the parked sun-arc (issue #34) — merged forward past HLW-023, SW bumped to v24. Adds the client-side sunrise/sunset sun-arc card to the home page (no backend). Cascade + connector fix on /water preserved. Closes #34.