### PR TITLE
HLW-021: sun-arc remaining-daylight readout

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -940,9 +940,11 @@
     if(isNaN(rise.valueOf())||isNaN(set.valueOf())){card.hidden=true;return;}
     $("sunriseT").textContent=fmt(rise);
     $("sunsetT").textContent=fmt(set);
-    var mins=Math.max(0,Math.round((set-rise)/60000));
-    $("sunDaylight").textContent=Math.floor(mins/60)+"h "+(mins%60)+"m of daylight";
     var frac=(now-rise)/(set-rise), day=frac>=0&&frac<=1, tc=Math.max(0,Math.min(1,frac));
+    var hm=function(ms){var m=Math.max(0,Math.round(ms/60000));return Math.floor(m/60)+"h "+(m%60)+"m";};
+    $("sunDaylight").textContent = now<rise ? ("Sunrise in "+hm(rise-now))
+      : now>set ? (hm(set-rise)+" of daylight today")
+      : (hm(set-now)+" of daylight left");
     var x=bez(tc,24,150,276), y=bez(tc,78,-58,78);
     var dot=$("sunDot"), halo=$("sunDotHalo");
     dot.setAttribute("cx",x.toFixed(1)); dot.setAttribute("cy",y.toFixed(1));

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,5 +1,5 @@
 /* Havasu Lake Weather — service worker (installability + offline shell) */
-const CACHE = "havasu-wx-v24";
+const CACHE = "havasu-wx-v25";
 const SHELL = [
   "/", "/index.html", "/water.html", "/manifest.json", "/sw-register.js",
   "/assets/icon-192.png", "/assets/icon-512.png", "/assets/icon-180.png",


### PR DESCRIPTION
Small enhancement to the live sun-arc: the daylight line now shows **remaining** daylight ("Xh Ym of daylight left") during the day, "Sunrise in Xh Ym" before sunrise, and total after sunset. Client-side, updates each minute. Site-only, SW v25.