### PR TITLE
HLW-026: 'Where Havasu's water goes' explainer on /water

### DIFF
--- a/docs/issues/HLW-026-water-destinations.md
+++ b/docs/issues/HLW-026-water-destinations.md
@@ -1,0 +1,34 @@
+# HLW-026: "Where Havasu's water goes" explainer on /water
+
+- **Status:** in-progress (built + previewed; awaiting deploy approval)
+- **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/48
+- **Branch:** `feat/HLW-026-water-destinations`
+- **Created:** 2026-08-24
+
+## Summary
+
+Static explainer card on `/water`, below the cascade: at Lake Havasu the Colorado splits —
+most continues downstream through Parker Dam (already shown), but two big aqueducts pump
+water out right here. Answers "where does the lake's water go?"
+
+- **→ Southern California** — MWD Colorado River Aqueduct (Whitsett Intake ~2 mi above Parker
+  Dam → 242 mi to LA/San Diego area). **~0.9M acre-ft/yr**, ~19M people.
+- **→ Central Arizona** — CAP / Mark Wilmer Pumping Plant → Phoenix & Tucson. **~0.95M ac-ft/yr**.
+
+## Why static (not live)
+
+Researched (see chat): the daily MWD/CAP diversions are in Reclamation's LC g4000 **HTML**
+report, but the machine-readable `accumweb.json` MWD/CAP series are empty (0/365; only SNWA
+populated). So a live daily number would require a fragile HTML scrape. Annual volumes are
+authoritative and stable → static card is the right call. (A live-daily version stays a
+possible follow-up if the JSON ever populates or we accept the scrape.)
+
+## Details
+
+- `web/water.html`: new `.card` after `#cascade` with a lead + two destination rows +
+  a "19 million people" note. Pure markup/CSS — no data fetch, no backend. SW → v30.
+
+## Acceptance
+
+- [x] Card renders after the cascade, matches the dark theme, 0 console errors.
+- [ ] Deploy (site-only) — **gated on Chad's go**.

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,5 +1,5 @@
 /* Havasu Lake Weather — service worker (installability + offline shell) */
-const CACHE = "havasu-wx-v29";
+const CACHE = "havasu-wx-v30";
 const SHELL = [
   "/", "/index.html", "/water.html", "/radar.html", "/manifest.json", "/sw-register.js",
   "/assets/icon-192.png", "/assets/icon-512.png", "/assets/icon-180.png",

--- a/web/water.html
+++ b/web/water.html
@@ -225,6 +225,24 @@
     <div class="casc-intro">The Colorado, top to bottom — every drop that reaches Lake Havasu passes through these first.</div>
     <div id="cascade" class="cascade" aria-label="Colorado River — Lake Powell down to Lake Havasu"></div>
 
+
+    <section class="card" id="histCard" hidden>
+      <h2>Lake Havasu · vs history <span class="src">USBR RISE</span></h2>
+      <div class="lk-history" id="lakeHistory">
+        <div class="lk-hist-txt" id="lakeHistTxt"></div>
+        <svg class="lk-spark" id="lakeSpark" viewBox="0 0 300 46" preserveAspectRatio="none" role="img" aria-label="Lake Havasu storage by year"></svg>
+        <div class="lk-spark-cap" id="lakeSparkCap"></div>
+      </div>
+    </section>
+
+    <section class="card" id="chartCard" hidden>
+      <h2>Recent flow <span class="src">last 30 days · cfs</span></h2>
+      <div class="chart-legend"><span class="lg lg-in">Davis in</span><span class="lg lg-out">Parker out</span></div>
+      <svg id="flowChart" viewBox="0 0 320 130" preserveAspectRatio="none" role="img" aria-label="Recent dam releases"></svg>
+    </section>
+
+    <div id="notes"></div>
+
     <!-- Where Havasu's water goes — static explainer (HLW-026) -->
     <section class="card" aria-label="Where Lake Havasu's water goes">
       <h2>Where Havasu's water goes <span class="src">annual &middot; USBR / MWD</span></h2>
@@ -247,23 +265,6 @@
       </div>
       <div class="wgoes-note">Between them these aqueducts serve close to <b>19 million</b> Southern Californians (MWD) plus much of Arizona's cities and farms &mdash; a big draw on the lower river.</div>
     </section>
-
-    <section class="card" id="histCard" hidden>
-      <h2>Lake Havasu · vs history <span class="src">USBR RISE</span></h2>
-      <div class="lk-history" id="lakeHistory">
-        <div class="lk-hist-txt" id="lakeHistTxt"></div>
-        <svg class="lk-spark" id="lakeSpark" viewBox="0 0 300 46" preserveAspectRatio="none" role="img" aria-label="Lake Havasu storage by year"></svg>
-        <div class="lk-spark-cap" id="lakeSparkCap"></div>
-      </div>
-    </section>
-
-    <section class="card" id="chartCard" hidden>
-      <h2>Recent flow <span class="src">last 30 days · cfs</span></h2>
-      <div class="chart-legend"><span class="lg lg-in">Davis in</span><span class="lg lg-out">Parker out</span></div>
-      <svg id="flowChart" viewBox="0 0 320 130" preserveAspectRatio="none" role="img" aria-label="Recent dam releases"></svg>
-    </section>
-
-    <div id="notes"></div>
 
     <div class="foot">
       Lake level: USGS · Dam releases &amp; water temp: USBR RISE · updates ~hourly.<br>

--- a/web/water.html
+++ b/web/water.html
@@ -179,6 +179,19 @@
   .casc-flow .pill .cc{font-size:.64rem;font-weight:800;text-transform:uppercase;letter-spacing:.03em;padding:1px 7px;border-radius:999px;}
   .cc.chip-low{background:rgba(255,191,92,.22);color:var(--gold);} .cc.chip-normal{background:rgba(47,185,196,.2);color:var(--teal-deep);} .cc.chip-high{background:rgba(255,122,77,.24);color:var(--coral-deep);}
   .casc-intro{font-size:.84rem;font-weight:650;color:var(--ink-soft);line-height:1.4;margin:2px 2px 4px;}
+  /* where Havasu's water goes (HLW-026) */
+  .wgoes-lead{font-size:.86rem;font-weight:650;color:var(--ink-soft);line-height:1.42;margin:2px 0 12px;}
+  .wgoes-row{display:flex;align-items:center;gap:12px;padding:12px 0;border-top:1px solid rgba(255,255,255,.08);}
+  .wgoes-row:first-of-type{border-top:0;padding-top:2px;}
+  .wgoes-dir{flex:none;width:104px;font-weight:800;font-size:.82rem;color:var(--teal-deep);}
+  .wgoes-body{flex:1;min-width:0;}
+  .wgoes-name{font-weight:800;font-size:.95rem;}
+  .wgoes-sub{font-size:.76rem;font-weight:600;color:var(--ink-faint);margin-top:2px;line-height:1.35;}
+  .wgoes-vol{flex:none;text-align:right;}
+  .wgoes-vol b{font-size:1.15rem;font-weight:800;color:var(--teal-deep);font-variant-numeric:tabular-nums;}
+  .wgoes-vol small{display:block;font-size:.62rem;font-weight:700;color:var(--ink-faint);text-transform:uppercase;letter-spacing:.03em;}
+  .wgoes-note{margin-top:12px;font-size:.77rem;font-weight:600;color:var(--ink-faint);line-height:1.42;}
+  .wgoes-note b{color:var(--ink-soft);}
   .casc-note{font-size:.72rem;font-weight:600;color:var(--ink-faint);text-align:center;margin-top:2px;}
   @media (min-width:560px){ .lbl .cfs{font-size:1.5rem;} }
 </style>
@@ -211,6 +224,29 @@
     <div id="warnings"></div>
     <div class="casc-intro">The Colorado, top to bottom — every drop that reaches Lake Havasu passes through these first.</div>
     <div id="cascade" class="cascade" aria-label="Colorado River — Lake Powell down to Lake Havasu"></div>
+
+    <!-- Where Havasu's water goes — static explainer (HLW-026) -->
+    <section class="card" aria-label="Where Lake Havasu's water goes">
+      <h2>Where Havasu's water goes <span class="src">annual &middot; USBR / MWD</span></h2>
+      <p class="wgoes-lead">At Lake Havasu the Colorado splits: most keeps flowing downstream through Parker Dam, but two big aqueducts pump water out right here.</p>
+      <div class="wgoes-row">
+        <span class="wgoes-dir">&rarr; So. California</span>
+        <div class="wgoes-body">
+          <div class="wgoes-name">MWD Colorado River Aqueduct</div>
+          <div class="wgoes-sub">Whitsett Intake, ~2 mi above Parker Dam &rarr; 242 mi of pumps, tunnels &amp; canals to the LA / San Diego area.</div>
+        </div>
+        <div class="wgoes-vol"><b>~0.9M</b><small>acre-ft/yr</small></div>
+      </div>
+      <div class="wgoes-row">
+        <span class="wgoes-dir">&rarr; Central Arizona</span>
+        <div class="wgoes-body">
+          <div class="wgoes-name">Central Arizona Project (CAP)</div>
+          <div class="wgoes-sub">Mark Wilmer Pumping Plant &rarr; 336 mi to Phoenix &amp; Tucson.</div>
+        </div>
+        <div class="wgoes-vol"><b>~0.95M</b><small>acre-ft/yr</small></div>
+      </div>
+      <div class="wgoes-note">Between them these aqueducts serve close to <b>19 million</b> Southern Californians (MWD) plus much of Arizona's cities and farms &mdash; a big draw on the lower river.</div>
+    </section>
 
     <section class="card" id="histCard" hidden>
       <h2>Lake Havasu · vs history <span class="src">USBR RISE</span></h2>


### PR DESCRIPTION
Static explainer card on /water (below the cascade): at Lake Havasu the Colorado splits — most continues downstream through Parker Dam, but two aqueducts pump water out. **→ Southern California** (MWD Colorado River Aqueduct, Whitsett Intake ~2 mi above Parker Dam, ~0.9M ac-ft/yr, ~19M people) and **→ Central Arizona** (CAP / Mark Wilmer, ~0.95M ac-ft/yr). Pure markup/CSS, no backend/data. SW v30. Static because the daily MWD/CAP diversion isn't in Reclamation's JSON feed (only the HTML report); annual volumes are authoritative. Verified: renders after the cascade, 0 console errors. Closes #48