### PR TITLE
chore: skip service worker on localhost (dev preview fix)

### DIFF
--- a/web/sw-register.js
+++ b/web/sw-register.js
@@ -6,6 +6,17 @@
 (function () {
   if (!("serviceWorker" in navigator)) return;
 
+  // Dev: never keep a service worker on localhost — it caches the app shell and forces
+  // a fresh port between edits (the cache is scoped to scheme+host+port). Unregister any
+  // leftover worker + clear its caches, then bail. Production (havasulakeweather.com)
+  // registers as normal, so this is a no-op there.
+  var host = location.hostname;
+  if (host === "localhost" || host === "127.0.0.1" || host === "::1") {
+    navigator.serviceWorker.getRegistrations().then(function (rs) { rs.forEach(function (r) { r.unregister(); }); }).catch(function () {});
+    if (window.caches && caches.keys) caches.keys().then(function (ks) { ks.forEach(function (k) { caches.delete(k); }); }).catch(function () {});
+    return;
+  }
+
   var refreshing = false;
   navigator.serviceWorker.addEventListener("controllerchange", function () {
     if (refreshing) return;      // the waiting worker took control — reload once to pick it up


### PR DESCRIPTION
The PWA service worker caches the app shell scoped to scheme+host+port, so on localhost a reload served the stale copy — which is why previews needed a fresh port each edit. This guards `sw-register.js` to bail on `localhost`/`127.0.0.1` (unregister any leftover worker + clear caches, then return). One dev port now works with a normal reload. Mirrors the existing GA domain-guard; **no-op in production** (the live domain still registers normally). No SW-version bump needed since prod behavior is unchanged.