### PR TITLE
HLW-027: CI/CD — GitHub Actions PR checks + deploy on merge to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,83 @@
+name: CI
+
+# PR checks — fast, and require NO AWS credentials. Runs on every PR into main.
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  checks:
+    name: tests · syntax · secret-scan · sw-bump
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # need base history for the diff-based checks
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: npm
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Unit tests (node --test)
+        run: npm test
+
+      - name: Syntax check (all JS/MJS)
+        run: git ls-files '*.js' '*.mjs' | xargs -r -n1 node --check
+
+      - name: Fetch base branch
+        run: git fetch --no-tags origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+
+      - name: Secret scan (added lines only)
+        run: |
+          base="origin/${{ github.base_ref }}"
+          # Added lines only; a line tagged `ci-allow-hex` is an intentional, reviewed
+          # constant (e.g. a public OIDC thumbprint) and is exempt.
+          added="$(git diff "$base...HEAD" | grep -E '^\+' | grep -Ev '^\+\+\+' | grep -Ev 'ci-allow-hex' || true)"
+          hits="$(printf '%s\n' "$added" | grep -cE '[0-9a-fA-F]{30,}' || true)"
+          if [ "${hits:-0}" -ne 0 ]; then
+            echo "::error::Possible secret: ${hits} added line(s) contain a 30+ hex-char run (API key / PASSKEY?)."
+            printf '%s\n' "$added" | grep -nE '[0-9a-fA-F]{30,}' || true
+            exit 1
+          fi
+          echo "Secret scan clean — no long hex runs in added lines."
+
+      - name: Service-worker cache bump (when web/ changed)
+        run: |
+          base="origin/${{ github.base_ref }}"
+          if git diff --name-only "$base...HEAD" | grep -q '^web/'; then
+            old="$(git show "$base:web/sw.js" | grep -oE 'havasu-wx-v[0-9]+' | head -1)"
+            new="$(grep -oE 'havasu-wx-v[0-9]+' web/sw.js | head -1)"
+            echo "web/ changed — sw.js CACHE old=${old:-none} new=${new:-none}"
+            if [ -z "$new" ]; then
+              echo "::error::could not read a havasu-wx-vN CACHE version from web/sw.js"; exit 1
+            fi
+            if [ "$old" = "$new" ]; then
+              echo "::error::web/ changed but web/sw.js CACHE ($new) was not bumped — installed PWAs won't pick up the update."
+              exit 1
+            fi
+            echo "SW cache bumped OK: $old -> $new"
+          else
+            echo "No web/ changes — SW cache check skipped."
+          fi
+
+  sam-validate:
+    name: sam validate --lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
+      - name: Validate template (offline cfn-lint — no AWS creds)
+        run: sam validate --lint --region us-west-2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,109 @@
+name: Deploy
+
+# Merge to main = deploy. Path-filtered: the site job runs only when web/ changed;
+# the ingest (SAM) job runs only when ingest/src, template.yaml or samconfig.toml changed.
+# Auth is via GitHub OIDC assuming arn:aws:iam::648581682379:role/havasu-github-deploy
+# (created once from infra/github-oidc.yaml) — NO long-lived AWS keys are stored in GitHub.
+on:
+  push:
+    branches: [main]
+
+permissions:
+  id-token: write # required for OIDC
+  contents: read
+
+concurrency:
+  group: deploy-main
+  cancel-in-progress: false
+
+env:
+  AWS_DEPLOY_ROLE: arn:aws:iam::648581682379:role/havasu-github-deploy
+
+jobs:
+  detect:
+    name: detect changed areas
+    runs-on: ubuntu-latest
+    outputs:
+      site: ${{ steps.filter.outputs.site }}
+      ingest: ${{ steps.filter.outputs.ingest }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: filter
+        run: |
+          before="${{ github.event.before }}"
+          # First push (zero SHA) or a rewritten history: git cat-file -e fails → treat all as changed.
+          if [ -z "$before" ] || ! git cat-file -e "${before}^{commit}" 2>/dev/null; then
+            echo "No usable base commit — treating all paths as changed."
+            changed="$(git ls-files)"
+          else
+            changed="$(git diff --name-only "$before" "${{ github.sha }}")"
+          fi
+          echo "Changed files:"; printf '%s\n' "$changed"
+          site=false; ingest=false
+          printf '%s\n' "$changed" | grep -qE '^web/' && site=true || true
+          printf '%s\n' "$changed" | grep -qE '^(ingest/src/|template\.yaml$|samconfig\.toml$)' && ingest=true || true
+          echo "site=$site"   >> "$GITHUB_OUTPUT"
+          echo "ingest=$ingest" >> "$GITHUB_OUTPUT"
+          echo "Deploy plan → site=$site ingest=$ingest"
+
+  deploy-site:
+    name: site (S3 + CloudFront, us-east-1)
+    needs: detect
+    if: needs.detect.outputs.site == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_DEPLOY_ROLE }}
+          aws-region: us-east-1
+      - name: Sync web/ to the site bucket
+        run: aws s3 sync web/ s3://havasu-weather-site-648581682379/ --delete --region us-east-1
+      - name: Invalidate CloudFront
+        run: aws cloudfront create-invalidation --distribution-id E1FK70K9FGVU2M --paths "/*"
+
+  deploy-ingest:
+    name: ingest/data stack (SAM, us-west-2)
+    needs: detect
+    if: needs.detect.outputs.ingest == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+      - uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_DEPLOY_ROLE }}
+          aws-region: us-west-2
+      - name: sam build
+        run: sam build
+      - name: Deploy — preserving the NoEcho station + WU keys
+        run: |
+          # The station PASSKEY + WU key are NoEcho SAM params. They live ONLY in the
+          # deployed read Lambda's env — read them back here so a redeploy can't reset
+          # them to empty. Kept in a shell var within this one step (never in outputs).
+          key="$(aws lambda get-function-configuration --function-name havasu-weather-read \
+                   --region us-west-2 --query 'Environment.Variables.STATION_KEY' --output text)"
+          wu="$(aws lambda get-function-configuration --function-name havasu-weather-read \
+                   --region us-west-2 --query 'Environment.Variables.WU_API_KEY' --output text)"
+          if [ -z "$key" ] || [ "$key" = "None" ]; then
+            echo "::error::STATION_KEY is empty on the live read Lambda — aborting so we don't wipe it."; exit 1
+          fi
+          if [ -z "$wu" ] || [ "$wu" = "None" ]; then
+            echo "::error::WU_API_KEY is empty on the live read Lambda — aborting so we don't wipe it."; exit 1
+          fi
+          echo "::add-mask::$key"; echo "::add-mask::$wu"
+          sam deploy --config-env ci --no-confirm-changeset --no-fail-on-empty-changeset \
+            --parameter-overrides "AllowedStationKeys=$key" "WuApiKey=$wu"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,9 @@ plus free public data (NWS, USGS, USBR RISE, Weather Underground).
    every time, for features and small fixes alike. Merging the PR and running the deploy
    commands are each a separate, explicit call. The only exception is an instruction that
    literally says to ship ("merge and deploy", "deploy it", "take it live"). When unsure, ask.
+   **As of HLW-027 the deploy is executed by GitHub Actions on merge to `main`** (see the
+   CI/CD section) — so "the deploy" is now the *merge itself*, which is Chad's call. The
+   manual `sam deploy` / `s3 sync` commands below remain the fallback/bootstrap path.
 5. **Git is not a deploy.** Committing and pushing *branches* is expected (messages end
    with the `Co-Authored-By` trailer). Merging PRs and deploying are Chad's calls.
 
@@ -45,9 +48,31 @@ plus free public data (NWS, USGS, USBR RISE, Weather Underground).
 1. Discuss the idea → gather info → **present a plan** (no code yet).
 2. On approval → create `HLW-###.md` + gh issue + a `feat/HLW-###-slug` branch.
 3. Build on the branch — mock-first where a preview helps (see mock params below).
-4. Push the branch and **open a PR** that references the ticket. Chad reviews + merges.
-5. **Ask before deploying.** After merge, on approval → deploy + verify live.
+4. Push the branch and **open a PR** that references the ticket. **CI runs the PR checks**
+   (tests, syntax, secret-scan, SW-bump, `sam validate`). Chad reviews + merges.
+5. **Merging to `main` deploys** (GitHub Actions, path-filtered — site and/or ingest).
+   So propose the merge and let Chad make the call; that merge is the deploy. Verify live
+   after the workflow finishes.
 6. Close: set the ticket to `done`, note what shipped.
+
+## CI/CD (GitHub Actions — HLW-027)
+
+- **PR checks** (`.github/workflows/ci.yml`, on every PR to `main`, no AWS creds): unit
+  tests (`npm test` → `node --test`, 53 tests over the pure logic), `node --check` syntax
+  on all JS, a **secret scan** (fails if an added line has a 30+ hex-char run), a
+  **service-worker cache-bump** check (fails if `web/` changed but `havasu-wx-vN` wasn't
+  bumped), and `sam validate --lint`.
+- **Deploy on merge to `main`** (`.github/workflows/deploy.yml`), path-filtered:
+  - site job → `aws s3 sync web/` + CloudFront invalidation, only if `web/` changed;
+  - ingest job → `sam build && sam deploy --config-env ci`, only if
+    `ingest/src`/`template.yaml`/`samconfig.toml` changed.
+  - The NoEcho station + WU keys are read back from the live read Lambda in-job and passed
+    to `--parameter-overrides`, so they never live in GitHub and a redeploy can't wipe them.
+- **Auth = OIDC, no stored keys.** Actions assume `havasu-github-deploy` (trust locked to
+  this repo's `main`). Bootstrapped once from `infra/github-oidc.yaml` (see `infra/README.md`);
+  the role ARN is hardcoded in the workflow.
+- **Tests live in `ingest/test/*.test.mjs`**; run locally with `npm test`. Add a case when
+  you touch the pure helpers in `ingest/src/{nws,water,read}.js`.
 
 ## Infra quick-reference (non-secret)
 
@@ -62,6 +87,7 @@ plus free public data (NWS, USGS, USBR RISE, Weather Underground).
 | Site bucket | `havasu-weather-site-648581682379` |
 | Site CloudFront | `E1FK70K9FGVU2M` → havasulakeweather.com |
 | Lambdas | `havasu-weather-ingest`, `havasu-weather-read`, `havasu-weather-pws-ingest` |
+| CI/CD deploy role | `havasu-github-deploy` (OIDC, main-only) — `arn:aws:iam::648581682379:role/havasu-github-deploy`, from `infra/github-oidc.yaml` |
 | Secrets (never commit) | station PASSKEY + WU read key — NoEcho SAM params `AllowedStationKeys`, `WuApiKey` |
 
 ## API endpoints (read Lambda, served under CloudFront `/api/*`)

--- a/docs/issues/HLW-027-cicd.md
+++ b/docs/issues/HLW-027-cicd.md
@@ -55,6 +55,6 @@ path. CLAUDE.md updated to reflect this.
 ## Acceptance
 
 - [x] `npm test` → 53/53 pass locally.
-- [ ] CI workflow green on this PR.
+- [x] CI workflow green on this PR (#52 — both jobs pass).
 - [ ] OIDC stack deployed once (gated).
 - [ ] First merge deploys the ingest stack cleanly; site skipped.

--- a/docs/issues/HLW-027-cicd.md
+++ b/docs/issues/HLW-027-cicd.md
@@ -1,0 +1,60 @@
+# HLW-027: CI/CD with GitHub Actions — PR checks + deploy on merge to main
+
+- **Status:** in-progress (built on branch; awaiting review + one-time OIDC bootstrap)
+- **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/51
+- **Branch:** `feat/HLW-027-cicd`
+- **Created:** 2026-08-23
+
+## Summary
+
+There were **no tests and no CI** before this. This adds:
+
+1. A dependency-free unit-test suite (Node's built-in `node --test`, 53 tests) over the
+   pure logic: NWS forecast day-pairing + glyphs + "rain soon", alert normalization,
+   the Colorado cascade (net-flow rising/draining/steady, % full, vs-history), and the
+   rain-state debounce. No new dependencies.
+2. **PR checks** (`.github/workflows/ci.yml`) — runs on every PR into `main`, needs **no
+   AWS creds**: unit tests, `node --check` syntax on all JS, a secret scan (no 30+ hex
+   runs in added lines), a service-worker cache-bump check (fails if `web/` changed but
+   `havasu-wx-vN` wasn't bumped), and `sam validate --lint`.
+3. **Deploy on merge to main** (`.github/workflows/deploy.yml`) — path-filtered:
+   - site job → `aws s3 sync web/` + CloudFront invalidation (us-east-1), only if `web/` changed.
+   - ingest job → `sam build && sam deploy` (us-west-2), only if `ingest/src`/`template.yaml`/`samconfig.toml` changed.
+   - Preserves the NoEcho station + WU keys by reading them from the live read Lambda's
+     env in-job, so they never live in GitHub and a redeploy can't wipe them.
+4. **OIDC auth** (`infra/github-oidc.yaml`) — a GitHub OIDC provider + a `havasu-github-deploy`
+   role scoped to `repo:cwoskoski/havasulakeweather:ref:refs/heads/main`. No long-lived
+   AWS keys in GitHub. Role ARN is hardcoded in the workflow (ARNs aren't secret).
+
+## Operating-model change
+
+This shifts the deploy gate: **merging a PR to `main` now deploys automatically.** The
+gate becomes the merge (Chad's call) rather than a separate manual deploy command. The
+manual `sam deploy` / `s3 sync` commands in CLAUDE.md remain as the fallback / bootstrap
+path. CLAUDE.md updated to reflect this.
+
+## Rollout (all gated on Chad)
+
+1. Review + merge this PR's **files** — but note: merging triggers the pipeline. Before
+   the OIDC role exists, the deploy jobs will fail at the auth step (harmless). So:
+2. **First**, bootstrap OIDC once: `aws cloudformation deploy ... infra/github-oidc.yaml`
+   (see `infra/README.md`). This is an AWS change → **gated**.
+3. **Then** merge to `main`. This PR touches `ingest/src/water.js` (added `export` on
+   `netFlow`/`pctFull`/`contextFor` for testing — behavior-neutral), so the ingest job
+   will deploy the read Lambda; no `web/` change, so the site job is skipped.
+
+## Files
+
+- `.github/workflows/ci.yml`, `.github/workflows/deploy.yml`
+- `infra/github-oidc.yaml`, `infra/README.md`
+- `ingest/test/{forecast,water,rain}.test.mjs`; root `package.json` → `"test": "node --test"`
+- `ingest/src/water.js` — `export` added to `netFlow`/`pctFull`/`contextFor`
+- `samconfig.toml` — added `[ci.deploy.parameters]` (no `profile`, for OIDC creds)
+- `CLAUDE.md` — CI/CD section + deploy-model note
+
+## Acceptance
+
+- [x] `npm test` → 53/53 pass locally.
+- [ ] CI workflow green on this PR.
+- [ ] OIDC stack deployed once (gated).
+- [ ] First merge deploys the ingest stack cleanly; site skipped.

--- a/docs/issues/HLW-027-cicd.md
+++ b/docs/issues/HLW-027-cicd.md
@@ -1,6 +1,6 @@
 # HLW-027: CI/CD with GitHub Actions — PR checks + deploy on merge to main
 
-- **Status:** in-progress (built on branch; awaiting review + one-time OIDC bootstrap)
+- **Status:** in-progress (built; CI green; OIDC bootstrapped — awaiting merge of #52)
 - **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/51
 - **Branch:** `feat/HLW-027-cicd`
 - **Created:** 2026-08-23
@@ -56,5 +56,5 @@ path. CLAUDE.md updated to reflect this.
 
 - [x] `npm test` → 53/53 pass locally.
 - [x] CI workflow green on this PR (#52 — both jobs pass).
-- [ ] OIDC stack deployed once (gated).
+- [x] OIDC stack deployed once (`havasu-github-oidc`, us-east-1; role + provider verified).
 - [ ] First merge deploys the ingest stack cleanly; site skipped.

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,58 @@
+# infra/ — one-time bootstrap for CI/CD
+
+The day-to-day stacks are `template.yaml` (ingest/data, us-west-2) and
+`site-template.yaml` (site, us-east-1). This folder holds infra you deploy **once**.
+
+## `github-oidc.yaml` — GitHub Actions OIDC + deploy role
+
+Lets GitHub Actions deploy to AWS with **no long-lived keys in GitHub**. Actions on
+`main` mint a short-lived OIDC token and assume `arn:aws:iam::648581682379:role/havasu-github-deploy`.
+The role's trust is locked to `repo:cwoskoski/havasulakeweather:ref:refs/heads/main`, so
+only this repo's `main` branch can assume it. That ARN is already referenced in
+`.github/workflows/deploy.yml`.
+
+### Deploy it (once) — this IS an AWS change, so it's gated on approval
+
+```bash
+# If the account has NO GitHub OIDC provider yet (first time):
+aws cloudformation deploy \
+  --template-file infra/github-oidc.yaml \
+  --stack-name havasu-github-oidc \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --profile havasu --region us-east-1
+
+# If a token.actions.githubusercontent.com provider ALREADY exists in the account,
+# reuse it instead of creating a duplicate (creation would fail):
+aws iam list-open-id-connect-providers --profile havasu   # find its ARN
+aws cloudformation deploy \
+  --template-file infra/github-oidc.yaml \
+  --stack-name havasu-github-oidc \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --parameter-overrides CreateOIDCProvider=false ExistingOIDCProviderArn=<arn> \
+  --profile havasu --region us-east-1
+```
+
+Region doesn't matter (IAM is global); us-east-1 is fine. `CAPABILITY_NAMED_IAM`
+is required because the role has a fixed name (`havasu-github-deploy`).
+
+### After it's created
+
+Nothing else to wire up — the role ARN is already in `deploy.yml`. Push/merge to
+`main` and the **Deploy** workflow runs (site job if `web/` changed, ingest job if
+`ingest/src`/`template.yaml`/`samconfig.toml` changed).
+
+### If a deploy fails with `AccessDenied`
+
+The role's inline policy is scoped (see the file). SAM occasionally needs an action
+that isn't listed yet — add the specific `Action` to the relevant `Sid` and redeploy
+this stack. As a quick unblock you can temporarily attach `PowerUserAccess` +
+`IAMFullAccess`, but prefer adding the one missing action to keep least-privilege.
+
+## How the NoEcho secrets stay safe
+
+The station PASSKEY and WU read key are **NoEcho** SAM params. They live only in the
+deployed read Lambda's env. The deploy workflow reads them back
+(`aws lambda get-function-configuration ... STATION_KEY / WU_API_KEY`) and passes them
+to `sam deploy --parameter-overrides`, so a redeploy never resets them and the secrets
+never touch GitHub. The role can read them via `lambda:GetFunctionConfiguration` on
+`havasu-weather-*` only.

--- a/infra/github-oidc.yaml
+++ b/infra/github-oidc.yaml
@@ -1,0 +1,154 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  GitHub Actions OIDC provider + a scoped deploy role for havasulakeweather.
+  Lets ONLY this repo's `main` branch assume a role to deploy the static site
+  (S3 + CloudFront, us-east-1) and the ingest/data SAM stack (us-west-2) with NO
+  long-lived AWS keys stored in GitHub. Deploy ONCE — see infra/README.md.
+
+Parameters:
+  GitHubOwner:
+    Type: String
+    Default: cwoskoski
+  GitHubRepo:
+    Type: String
+    Default: havasulakeweather
+  GitHubBranch:
+    Type: String
+    Default: main
+    Description: Only this branch may assume the role (deploys run on push to main).
+  CreateOIDCProvider:
+    Type: String
+    AllowedValues: ["true", "false"]
+    Default: "true"
+    Description: >
+      "true" creates the token.actions.githubusercontent.com OIDC provider. If the
+      account already has one, set "false" and pass its ARN in ExistingOIDCProviderArn.
+  ExistingOIDCProviderArn:
+    Type: String
+    Default: ""
+    Description: ARN of an existing GitHub OIDC provider (only used when CreateOIDCProvider=false).
+
+Conditions:
+  MakeProvider: !Equals [!Ref CreateOIDCProvider, "true"]
+
+Resources:
+  GitHubOIDCProvider:
+    Condition: MakeProvider
+    Type: AWS::IAM::OIDCProvider
+    Properties:
+      Url: https://token.actions.githubusercontent.com
+      ClientIdList:
+        - sts.amazonaws.com
+      # GitHub's OIDC thumbprints. Modern IAM validates GitHub via its own trust
+      # store, but the resource still requires a non-empty ThumbprintList.
+      ThumbprintList:
+        - 6938fd4d98bab03faadb97b34396831e3780aea1 # ci-allow-hex: public GitHub OIDC thumbprint
+        - 1c58a3a8518e8759bf075b76b750d4f2df264fca # ci-allow-hex: public GitHub OIDC thumbprint
+
+  DeployRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: havasu-github-deploy
+      MaxSessionDuration: 3600
+      Description: Assumed by GitHub Actions (main branch) to deploy the site + ingest stack.
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Federated: !If [MakeProvider, !Ref GitHubOIDCProvider, !Ref ExistingOIDCProviderArn]
+            Action: sts:AssumeRoleWithWebIdentity
+            Condition:
+              StringEquals:
+                token.actions.githubusercontent.com:aud: sts.amazonaws.com
+              StringLike:
+                token.actions.githubusercontent.com:sub: !Sub "repo:${GitHubOwner}/${GitHubRepo}:ref:refs/heads/${GitHubBranch}"
+      Policies:
+        - PolicyName: havasu-deploy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              # ---- Site deploy: S3 sync to the site bucket ----
+              - Sid: SiteBucket
+                Effect: Allow
+                Action: [s3:ListBucket, s3:GetBucketLocation]
+                Resource: arn:aws:s3:::havasu-weather-site-648581682379
+              - Sid: SiteObjects
+                Effect: Allow
+                Action: [s3:PutObject, s3:GetObject, s3:DeleteObject]
+                Resource: arn:aws:s3:::havasu-weather-site-648581682379/*
+              # ---- Site deploy: CloudFront invalidation ----
+              - Sid: CloudFrontInvalidate
+                Effect: Allow
+                Action: [cloudfront:CreateInvalidation, cloudfront:GetInvalidation, cloudfront:GetDistribution]
+                Resource: !Sub "arn:aws:cloudfront::${AWS::AccountId}:distribution/E1FK70K9FGVU2M"
+              # ---- Ingest deploy: read the live NoEcho keys before sam deploy ----
+              - Sid: ReadLambdaKeys
+                Effect: Allow
+                Action: lambda:GetFunctionConfiguration
+                Resource: !Sub "arn:aws:lambda:us-west-2:${AWS::AccountId}:function:havasu-weather-*"
+              # ---- Ingest deploy: SAM / CloudFormation ----
+              - Sid: CloudFormation
+                Effect: Allow
+                Action: [cloudformation:*]
+                Resource: "*"
+              - Sid: ListBuckets
+                Effect: Allow
+                Action: s3:ListAllMyBuckets
+                Resource: "*"
+              - Sid: SamManagedArtifactBucket
+                Effect: Allow
+                Action:
+                  - s3:CreateBucket
+                  - s3:PutObject
+                  - s3:GetObject
+                  - s3:ListBucket
+                  - s3:GetBucketLocation
+                  - s3:PutBucketPolicy
+                  - s3:GetBucketPolicy
+                  - s3:PutBucketVersioning
+                  - s3:PutEncryptionConfiguration
+                  - s3:GetEncryptionConfiguration
+                  - s3:PutBucketPublicAccessBlock
+                  - s3:GetBucketPublicAccessBlock
+                  - s3:PutBucketTagging
+                Resource:
+                  - arn:aws:s3:::aws-sam-cli-managed-*
+                  - arn:aws:s3:::aws-sam-cli-managed-*/*
+              - Sid: SamManagedResources
+                Effect: Allow
+                Action:
+                  - lambda:*
+                  - apigateway:*
+                  - dynamodb:*
+                  - logs:*
+                  - events:*
+                  - scheduler:*
+                  - cloudfront:*
+                Resource: "*"
+              - Sid: ManageStackServiceRoles
+                Effect: Allow
+                Action:
+                  - iam:GetRole
+                  - iam:CreateRole
+                  - iam:DeleteRole
+                  - iam:AttachRolePolicy
+                  - iam:DetachRolePolicy
+                  - iam:PutRolePolicy
+                  - iam:DeleteRolePolicy
+                  - iam:GetRolePolicy
+                  - iam:ListRolePolicies
+                  - iam:ListAttachedRolePolicies
+                  - iam:TagRole
+                  - iam:UntagRole
+                  - iam:PassRole
+                  - iam:UpdateAssumeRolePolicy
+                Resource: !Sub "arn:aws:iam::${AWS::AccountId}:role/havasu-weather-*"
+
+Outputs:
+  DeployRoleArn:
+    Description: role-to-assume for .github/workflows/deploy.yml (already hardcoded there).
+    Value: !GetAtt DeployRole.Arn
+  OIDCProviderArn:
+    Description: The GitHub OIDC provider ARN.
+    Value: !If [MakeProvider, !Ref GitHubOIDCProvider, !Ref ExistingOIDCProviderArn]

--- a/ingest/src/water.js
+++ b/ingest/src/water.js
@@ -120,7 +120,7 @@ function lakeStatus(elev) {
 }
 
 // --- seasonal context + warnings (HLW-014) ---
-function contextFor(norm, value, month) {
+export function contextFor(norm, value, month) {
   if (value == null || !norm) return null;
   const b = norm.byMonth[String(month)];
   const level = !b ? "unknown" : value < b.p10 ? "low" : value > b.p90 ? "high" : "normal";
@@ -206,12 +206,12 @@ function warningsFor(lake, inflow, outflow) {
 }
 
 // --- Colorado cascade (HLW-023): ordered Powell → Havasu ---
-function pctFull(storageAf, capacityAf) {
+export function pctFull(storageAf, capacityAf) {
   return storageAf != null && capacityAf ? Math.round((100 * storageAf) / capacityAf) : null;
 }
 // Net flow (in − out) → rising / draining. ±200 cfs deadband so run-of-river lakes
 // (Mohave/Havasu, which pass water through) don't flicker around zero.
-function netFlow(inCfs, outCfs) {
+export function netFlow(inCfs, outCfs) {
   if (inCfs == null || outCfs == null) return null;
   const n = Math.round(inCfs - outCfs);
   return { netCfs: n, trend: n > 200 ? "rising" : n < -200 ? "draining" : "steady" };

--- a/ingest/test/forecast.test.mjs
+++ b/ingest/test/forecast.test.mjs
@@ -1,0 +1,188 @@
+/**
+ * Unit tests for the NWS forecast/alerts module (ingest/src/nws.js).
+ *
+ * Exercised entirely through the offline `?mock=<scenario>` paths — no network,
+ * no reliance on the real NWS API, fully deterministic. Uses Node's built-in
+ * test runner (node:test) + node:assert/strict, zero dependencies.
+ *
+ * Verified against nws.js:
+ *   MOCK_FORECAST scenario keys: "rain", "clear"
+ *   MOCK_ALERTS   scenario keys: "heat-warning", "heat-advisory", "flood",
+ *                                "flood-watch", "multi", "clear", "none"
+ *   forecast fields: { updatedAt, location, source, mock, office,
+ *                      rainSoon, hourly, daily, days }
+ *   rainSoon shape:  { likely, withinHours, at, maxProbNext12h }
+ *   days[] entry:    { date, weekday, hiF, loF, precipProb,
+ *                      shortForecast, glyph, isDaytime }
+ *   alert entry:     { id, event, severity, urgency, certainty, headline,
+ *                      description, instruction, onset, expires, senderName,
+ *                      category, tone }
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { getForecast, getAlerts } from "../src/nws.js";
+
+// Glyphs glyphFor() emits for wet conditions (thunderstorm / rain / snow).
+const WET_GLYPHS = new Set(["⛈️", "🌧️", "🌨️"]);
+const STORMY_RE = /thunder|storm|rain|shower/i;
+
+/* --------------------------------------------------------------- forecast -- */
+
+test("getForecast('rain') resolves to a mock forecast with a 7-day strip", async () => {
+  const fc = await getForecast("rain");
+
+  assert.equal(fc.source, "mock");
+  assert.equal(fc.mock, "rain");
+  assert.equal(typeof fc.location, "string");
+  assert.ok(fc.location.length > 0, "location should be a non-empty label");
+
+  assert.ok(Array.isArray(fc.days), "days should be an array");
+  assert.ok(fc.days.length >= 1 && fc.days.length <= 7, "days is up to 7 entries");
+});
+
+test("getForecast('rain') days each carry numeric-or-null temps, a weekday and a glyph", async () => {
+  const { days } = await getForecast("rain");
+
+  for (const d of days) {
+    assert.ok(d.hiF === null || typeof d.hiF === "number", "hiF is numeric or null");
+    assert.ok(d.loF === null || typeof d.loF === "number", "loF is numeric or null");
+    assert.ok(
+      d.precipProb === null || typeof d.precipProb === "number",
+      "precipProb is numeric or null",
+    );
+
+    assert.equal(typeof d.weekday, "string");
+    assert.ok(d.weekday.length > 0, "weekday should be non-empty");
+
+    assert.equal(typeof d.glyph, "string");
+    assert.ok(d.glyph.length > 0, "glyph should be a non-empty emoji");
+
+    assert.equal(typeof d.shortForecast, "string");
+    assert.equal(typeof d.date, "string");
+    assert.equal(typeof d.isDaytime, "boolean");
+  }
+});
+
+test("getForecast('rain') has a stormy day whose glyph is one of the wet glyphs", async () => {
+  const { days } = await getForecast("rain");
+
+  const stormy = days.filter((d) => STORMY_RE.test(d.shortForecast));
+  assert.ok(stormy.length >= 1, "at least one day should read as stormy/rainy");
+
+  // The stormy day (mock: "Showers And Thunderstorms Likely") must render a wet glyph.
+  assert.ok(
+    stormy.some((d) => WET_GLYPHS.has(d.glyph)),
+    `expected a wet glyph among stormy days, got: ${stormy.map((d) => d.glyph).join(" ")}`,
+  );
+});
+
+test("getForecast('rain') flags rainSoon.likely true and reports the peak probability", async () => {
+  const { rainSoon } = await getForecast("rain");
+
+  // Mock hourly probs [10,20,40,60,70,...] cross the 30% threshold at index 2.
+  assert.equal(rainSoon.likely, true, "wet scenario crosses the rain threshold");
+  assert.equal(rainSoon.withinHours, 2, "first hour at/above threshold is index 2");
+  assert.equal(rainSoon.at !== null, true, "an onset time is set when likely");
+  assert.equal(typeof rainSoon.maxProbNext12h, "number");
+  assert.equal(rainSoon.maxProbNext12h, 70, "peak of the mock hourly window");
+});
+
+test("getForecast('clear') days present, no wet glyphs and no stormy text", async () => {
+  const { days } = await getForecast("clear");
+
+  assert.ok(Array.isArray(days) && days.length >= 1, "days should be present");
+
+  for (const d of days) {
+    assert.ok(!WET_GLYPHS.has(d.glyph), `clear day should not use a wet glyph: ${d.glyph}`);
+    assert.ok(!STORMY_RE.test(d.shortForecast), `clear day should not read stormy: ${d.shortForecast}`);
+    assert.ok(d.glyph.length > 0, "glyph should still be a non-empty emoji");
+  }
+
+  // The plain "Sunny" days map to the sunny glyph per glyphFor().
+  assert.ok(
+    days.some((d) => d.glyph === "☀️"),
+    "expected at least one sunny ☀️ glyph in the clear forecast",
+  );
+});
+
+test("getForecast('clear') reports rainSoon.likely false below the threshold", async () => {
+  const { rainSoon } = await getForecast("clear");
+
+  // Mock hourly probs [0,0,1,2,1,...] never reach the 30% threshold.
+  assert.equal(rainSoon.likely, false, "dry scenario stays below the rain threshold");
+  assert.equal(rainSoon.at, null, "no onset time when not likely");
+  assert.equal(rainSoon.withinHours, null, "no within-hours when not likely");
+  assert.equal(rainSoon.maxProbNext12h, 2, "peak of the dry mock hourly window");
+});
+
+test("getForecast falls back to the clear scenario for an unknown mock key", async () => {
+  const fc = await getForecast("does-not-exist");
+
+  assert.equal(fc.source, "mock");
+  // Unknown key resolves via MOCK_FORECAST.clear -> dry rainSoon.
+  assert.equal(fc.rainSoon.likely, false);
+  assert.ok(Array.isArray(fc.days) && fc.days.length >= 1);
+});
+
+/* ----------------------------------------------------------------- alerts -- */
+
+test("getAlerts('clear') returns zero alerts", async () => {
+  const res = await getAlerts("clear");
+
+  assert.equal(res.source, "mock");
+  assert.equal(res.mock, "clear");
+  assert.equal(res.count, 0);
+  assert.ok(Array.isArray(res.alerts), "alerts should be an array");
+  assert.equal(res.alerts.length, 0, "clear scenario has no alerts");
+});
+
+test("getAlerts('heat-warning') returns a normalized heat alert", async () => {
+  const res = await getAlerts("heat-warning");
+
+  assert.equal(res.source, "mock");
+  assert.ok(res.count >= 1, "heat-warning should surface at least one alert");
+  assert.equal(res.alerts.length, res.count, "count matches alerts array length");
+
+  const a = res.alerts[0];
+  assert.equal(typeof a.id, "string");
+  assert.ok(a.id.length > 0, "alert id should be non-empty");
+  assert.equal(typeof a.event, "string");
+  assert.ok(a.event.length > 0, "alert event should be non-empty");
+  assert.equal(a.severity, "Severe");
+  assert.equal(a.category, "heat", "categoryOf() should classify heat events");
+  assert.equal(a.tone, "critical", "toneOf('Severe') should be critical");
+  assert.equal(a.senderName, "NWS Las Vegas NV (MOCK)");
+});
+
+test("getAlerts('flood') returns a normalized flood alert", async () => {
+  const res = await getAlerts("flood");
+
+  assert.ok(res.count >= 1, "flood should surface at least one alert");
+  const a = res.alerts[0];
+  assert.equal(a.category, "flood", "categoryOf() should classify flood events");
+  assert.equal(a.tone, "critical", "a Severe flood warning is critical toned");
+  assert.ok(typeof a.headline === "string" && a.headline.length > 0, "headline present");
+});
+
+test("getAlerts('multi') returns multiple alerts sorted by severity", async () => {
+  const res = await getAlerts("multi");
+
+  assert.equal(res.count, 2, "multi bundles a flood + a heat advisory");
+  assert.equal(res.alerts.length, 2);
+
+  // sortAlerts ranks Severe(1) before Moderate(2): flood should lead, heat trails.
+  assert.equal(res.alerts[0].category, "flood");
+  assert.equal(res.alerts[0].severity, "Severe");
+  assert.equal(res.alerts[1].category, "heat");
+  assert.equal(res.alerts[1].severity, "Moderate");
+});
+
+test("getAlerts falls back to clear for an unknown mock key", async () => {
+  const res = await getAlerts("nope-not-real");
+
+  assert.equal(res.source, "mock");
+  assert.equal(res.count, 0);
+  assert.deepEqual(res.alerts, []);
+});

--- a/ingest/test/rain.test.mjs
+++ b/ingest/test/rain.test.mjs
@@ -1,0 +1,109 @@
+// Unit tests for rainState(recent, latest) from ingest/src/read.js. Pure logic,
+// no AWS/network. Uses only Node's built-in runner (node:test) + node:assert/strict.
+//
+// Contract (verified against the source):
+//   rate(r)     = r.hourlyrainin when it's a number, else 0
+//   rainingNow  = rate(latest) > 0 OR any recent reading has rate > 0
+//   rateInHr    = rate(latest) or null (0 -> null)
+//   lastRainAt  = sk of the last wet recent reading, else latest.lastRainAt, else null
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { rainState } from "../src/read.js";
+
+test("raining now via the latest reading, recent empty", () => {
+  const latest = { hourlyrainin: 0.05, lastRainAt: "2026-08-23T10:00:00Z" };
+  const r = rainState([], latest);
+  assert.equal(r.rainingNow, true);
+  assert.equal(r.rateInHr, 0.05);
+  // no wet recent reading, so fall back to latest.lastRainAt
+  assert.equal(r.lastRainAt, "2026-08-23T10:00:00Z");
+});
+
+test("debounce: raining now because a recent reading was wet even though latest is dry", () => {
+  const recent = [
+    { hourlyrainin: 0, sk: "2026-08-23T09:00:00Z" },
+    { hourlyrainin: 0.02, sk: "2026-08-23T09:30:00Z" },
+    { hourlyrainin: 0, sk: "2026-08-23T09:45:00Z" },
+  ];
+  const latest = { hourlyrainin: 0 };
+  const r = rainState(recent, latest);
+  assert.equal(r.rainingNow, true); // held on by the wet reading in the window
+  assert.equal(r.rateInHr, null); // latest rate is 0 -> null
+  assert.equal(r.lastRainAt, "2026-08-23T09:30:00Z"); // the wet reading's sk
+});
+
+test("debounce: lastRainAt is the LAST wet reading when several are wet", () => {
+  const recent = [
+    { hourlyrainin: 0.03, sk: "2026-08-23T09:10:00Z" },
+    { hourlyrainin: 0, sk: "2026-08-23T09:20:00Z" },
+    { hourlyrainin: 0.01, sk: "2026-08-23T09:40:00Z" },
+  ];
+  const r = rainState(recent, { hourlyrainin: 0 });
+  assert.equal(r.rainingNow, true);
+  assert.equal(r.lastRainAt, "2026-08-23T09:40:00Z");
+});
+
+test("a wet recent reading takes precedence over latest.lastRainAt", () => {
+  const recent = [{ hourlyrainin: 0.02, sk: "WET_SK" }];
+  const latest = { hourlyrainin: 0.1, lastRainAt: "OLD_STAMP" };
+  const r = rainState(recent, latest);
+  assert.equal(r.lastRainAt, "WET_SK");
+});
+
+test("fully dry: rainingNow false, rateInHr null, lastRainAt from latest fallback", () => {
+  const recent = [
+    { hourlyrainin: 0, sk: "2026-08-23T09:00:00Z" },
+    { hourlyrainin: 0, sk: "2026-08-23T09:30:00Z" },
+  ];
+  const latest = { hourlyrainin: 0 }; // no lastRainAt
+  const r = rainState(recent, latest);
+  assert.equal(r.rainingNow, false);
+  assert.equal(r.rateInHr, null);
+  assert.equal(r.lastRainAt, null);
+});
+
+test("omitted recent array (undefined) is treated as empty", () => {
+  const r = rainState(undefined, { hourlyrainin: 0.1 });
+  assert.equal(r.rainingNow, true);
+  assert.equal(r.rateInHr, 0.1);
+  assert.equal(r.lastRainAt, null); // no wet recent, no latest.lastRainAt
+});
+
+test("empty recent + dry latest is fully dry", () => {
+  const r = rainState([], { hourlyrainin: 0 });
+  assert.equal(r.rainingNow, false);
+  assert.equal(r.rateInHr, null);
+  assert.equal(r.lastRainAt, null);
+});
+
+test("non-numeric hourlyrainin (string) is treated as 0", () => {
+  const latest = { hourlyrainin: "0.05" }; // string, not a number
+  const recent = [{ hourlyrainin: "0.1", sk: "2026-08-23T09:00:00Z" }];
+  const r = rainState(recent, latest);
+  assert.equal(r.rainingNow, false); // both rates coerced to 0
+  assert.equal(r.rateInHr, null);
+  assert.equal(r.lastRainAt, null); // no wet reading, no latest.lastRainAt
+});
+
+test("missing/null hourlyrainin is treated as 0", () => {
+  assert.equal(rainState([{ sk: "a" }], { hourlyrainin: null }).rainingNow, false);
+  assert.equal(rainState([{ hourlyrainin: undefined, sk: "a" }], {}).rainingNow, false);
+});
+
+test("latest raining overrides an all-dry recent window", () => {
+  const recent = [
+    { hourlyrainin: 0, sk: "2026-08-23T09:00:00Z" },
+    { hourlyrainin: 0, sk: "2026-08-23T09:30:00Z" },
+  ];
+  const r = rainState(recent, { hourlyrainin: 0.25, lastRainAt: "2026-08-23T10:00:00Z" });
+  assert.equal(r.rainingNow, true);
+  assert.equal(r.rateInHr, 0.25);
+  assert.equal(r.lastRainAt, "2026-08-23T10:00:00Z"); // no wet recent -> latest fallback
+});
+
+test("null latest does not throw and reads as dry", () => {
+  const r = rainState([], null);
+  assert.equal(r.rainingNow, false);
+  assert.equal(r.rateInHr, null);
+  assert.equal(r.lastRainAt, null);
+});

--- a/ingest/test/water.test.mjs
+++ b/ingest/test/water.test.mjs
@@ -1,0 +1,201 @@
+// Unit + light integration tests for ingest/src/water.js — the lake & river
+// helpers. Uses only Node's built-in runner (node:test) + node:assert/strict; no
+// jest/vitest/mocha, no network, no AWS. getWater is exercised through its
+// in-memory MOCK map so nothing touches DynamoDB or RISE/USGS.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { netFlow, pctFull, contextFor, getWater } from "../src/water.js";
+
+// --- netFlow(inCfs, outCfs) -> { netCfs, trend } with a ±200 cfs deadband -------
+
+test("netFlow: net above +200 cfs is rising", () => {
+  assert.deepEqual(netFlow(1000, 500), { netCfs: 500, trend: "rising" });
+});
+
+test("netFlow: net below -200 cfs is draining", () => {
+  assert.deepEqual(netFlow(500, 1000), { netCfs: -500, trend: "draining" });
+});
+
+test("netFlow: small positive net inside the deadband is steady", () => {
+  assert.deepEqual(netFlow(1000, 900), { netCfs: 100, trend: "steady" });
+});
+
+test("netFlow: small negative net inside the deadband is steady", () => {
+  assert.deepEqual(netFlow(900, 1000), { netCfs: -100, trend: "steady" });
+});
+
+test("netFlow: exactly +200 cfs stays steady (deadband is inclusive)", () => {
+  assert.deepEqual(netFlow(1200, 1000), { netCfs: 200, trend: "steady" });
+});
+
+test("netFlow: +201 cfs tips over into rising", () => {
+  assert.deepEqual(netFlow(1201, 1000), { netCfs: 201, trend: "rising" });
+});
+
+test("netFlow: exactly -200 cfs stays steady (deadband is inclusive)", () => {
+  assert.deepEqual(netFlow(1000, 1200), { netCfs: -200, trend: "steady" });
+});
+
+test("netFlow: -201 cfs tips over into draining", () => {
+  assert.deepEqual(netFlow(1000, 1201), { netCfs: -201, trend: "draining" });
+});
+
+test("netFlow: net is rounded to a whole cfs", () => {
+  // 500.7 - 100.2 = 400.5 -> Math.round -> 401
+  assert.deepEqual(netFlow(500.7, 100.2), { netCfs: 401, trend: "rising" });
+});
+
+test("netFlow: null inflow returns null", () => {
+  assert.equal(netFlow(null, 500), null);
+});
+
+test("netFlow: null outflow returns null", () => {
+  assert.equal(netFlow(500, null), null);
+});
+
+test("netFlow: undefined args return null", () => {
+  assert.equal(netFlow(undefined, 500), null);
+  assert.equal(netFlow(500, undefined), null);
+  assert.equal(netFlow(undefined, undefined), null);
+});
+
+// --- pctFull(storageAf, capacityAf) -> integer percent, or null ----------------
+
+test("pctFull: full storage reads 100", () => {
+  assert.equal(pctFull(619000, 619000), 100);
+});
+
+test("pctFull: partial storage is rounded to an integer", () => {
+  // 555000 / 619000 * 100 = 89.66... -> 90
+  assert.equal(pctFull(555000, 619000), 90);
+  // 1 / 3 * 100 = 33.33... -> 33
+  assert.equal(pctFull(1, 3), 33);
+  // 2 / 3 * 100 = 66.66... -> 67
+  assert.equal(pctFull(2, 3), 67);
+});
+
+test("pctFull: zero storage against a real capacity is 0, not null", () => {
+  assert.equal(pctFull(0, 100), 0);
+});
+
+test("pctFull: null/undefined storage returns null", () => {
+  assert.equal(pctFull(null, 100), null);
+  assert.equal(pctFull(undefined, 100), null);
+});
+
+test("pctFull: zero or missing capacity returns null (no divide-by-zero)", () => {
+  assert.equal(pctFull(500, 0), null);
+  assert.equal(pctFull(500, null), null);
+  assert.equal(pctFull(500, undefined), null);
+});
+
+// --- contextFor(norm, value, month) -> seasonal band classification -------------
+// norm shape mirrors ingest/data/water-normals.json:
+//   { byMonth: { "<month>": { p10, median, p90 } }, allTime: { min, max } }
+const NORM = {
+  byMonth: { "8": { p10: 100, median: 200, p90: 300 } },
+  allTime: { min: 10, max: 500 },
+};
+
+test("contextFor: null value returns null", () => {
+  assert.equal(contextFor(NORM, null, 8), null);
+});
+
+test("contextFor: missing norm returns null", () => {
+  assert.equal(contextFor(null, 200, 8), null);
+  assert.equal(contextFor(undefined, 200, 8), null);
+});
+
+test("contextFor: value below the monthly p10 is low, with band fields", () => {
+  assert.deepEqual(contextFor(NORM, 50, 8), {
+    level: "low",
+    monthLo: 100,
+    monthMed: 200,
+    monthHi: 300,
+    allLo: 10,
+    allHi: 500,
+  });
+});
+
+test("contextFor: value between p10 and p90 is normal", () => {
+  assert.equal(contextFor(NORM, 200, 8).level, "normal");
+});
+
+test("contextFor: value above the monthly p90 is high", () => {
+  assert.equal(contextFor(NORM, 400, 8).level, "high");
+});
+
+test("contextFor: exactly at p10 is normal (strict less-than boundary)", () => {
+  assert.equal(contextFor(NORM, 100, 8).level, "normal");
+});
+
+test("contextFor: exactly at p90 is normal (strict greater-than boundary)", () => {
+  assert.equal(contextFor(NORM, 300, 8).level, "normal");
+});
+
+test("contextFor: a month with no band is unknown but still returns all-time range", () => {
+  const c = contextFor(NORM, 200, 1); // no byMonth["1"]
+  assert.equal(c.level, "unknown");
+  assert.equal(c.monthLo, null);
+  assert.equal(c.monthMed, null);
+  assert.equal(c.monthHi, null);
+  assert.equal(c.allLo, 10);
+  assert.equal(c.allHi, 500);
+});
+
+// --- getWater(mock) -> full mock response, no AWS/network ------------------------
+const RESERVOIR_KEYS = ["powell", "mead", "mohave", "havasu"];
+const FLOW_KEYS = ["grandcanyon", "hoover", "davis", "parker"];
+
+test("getWater('normal'): tags the response as a mock", async () => {
+  const w = await getWater("normal");
+  assert.equal(w.source, "mock");
+  assert.equal(w.mock, "normal");
+  assert.equal(w.location, "Lake Havasu");
+  assert.equal(typeof w.updatedAt, "string");
+});
+
+test("getWater('normal'): cascade has 8 nodes — 4 reservoirs + 4 flows in order", async () => {
+  const w = await getWater("normal");
+  assert.ok(Array.isArray(w.cascade));
+  assert.equal(w.cascade.length, 8);
+
+  const reservoirs = w.cascade.filter((n) => n.type === "reservoir");
+  const flows = w.cascade.filter((n) => n.type === "flow");
+  assert.equal(reservoirs.length, 4);
+  assert.equal(flows.length, 4);
+  assert.deepEqual(reservoirs.map((n) => n.key), RESERVOIR_KEYS);
+  assert.deepEqual(flows.map((n) => n.key), FLOW_KEYS);
+});
+
+test("getWater('normal'): Lake Havasu node is the starred reservoir with numeric pctFull + a valid netTrend", async () => {
+  const w = await getWater("normal");
+  const havasu = w.cascade.find((n) => n.key === "havasu");
+  assert.ok(havasu, "expected a havasu node");
+  assert.equal(havasu.type, "reservoir");
+  assert.equal(havasu.star, true);
+  assert.equal(typeof havasu.pctFull, "number");
+  assert.ok(Number.isFinite(havasu.pctFull));
+  assert.ok(["rising", "draining", "steady"].includes(havasu.netTrend));
+});
+
+test("getWater: every real scenario yields an 8-node cascade with a starred Havasu", async () => {
+  for (const scenario of ["normal", "low-lake", "high-release"]) {
+    const w = await getWater(scenario);
+    assert.equal(w.source, "mock", `${scenario}: source`);
+    assert.equal(w.mock, scenario, `${scenario}: mock name`);
+    assert.equal(w.cascade.length, 8, `${scenario}: node count`);
+    const havasu = w.cascade.find((n) => n.key === "havasu");
+    assert.equal(havasu.star, true, `${scenario}: havasu starred`);
+    assert.equal(typeof havasu.pctFull, "number", `${scenario}: numeric pctFull`);
+    assert.ok(["rising", "draining", "steady"].includes(havasu.netTrend), `${scenario}: netTrend`);
+  }
+});
+
+test("getWater: an unknown scenario name falls back to the normal fixture shape", async () => {
+  const w = await getWater("does-not-exist");
+  assert.equal(w.source, "mock");
+  // MOCK[mock] || MOCK.normal — content defaults to normal, but the echoed name is preserved
+  assert.equal(w.mock, "does-not-exist");
+  assert.equal(w.cascade.length, 8);
+});

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "description": "Havasu Lake Weather — local dev runner for the read API + static site",
   "scripts": {
-    "dev": "node dev/server.mjs"
+    "dev": "node dev/server.mjs",
+    "test": "node --test"
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3",

--- a/samconfig.toml
+++ b/samconfig.toml
@@ -23,3 +23,14 @@ disable_rollback = false
 
 [default.local_invoke.parameters]
 profile = "havasu"
+
+# CI deploy env (GitHub Actions). Same stack/region as default, but NO `profile`
+# so it uses the ambient OIDC credentials from the assumed havasu-github-deploy role.
+# The workflow calls: sam deploy --config-env ci --parameter-overrides "AllowedStationKeys=..." "WuApiKey=..."
+[ci.deploy.parameters]
+stack_name = "havasu-weather-ingest"
+region = "us-west-2"
+resolve_s3 = true
+capabilities = "CAPABILITY_IAM"
+confirm_changeset = false
+disable_rollback = false


### PR DESCRIPTION
Closes #51. Ticket: `docs/issues/HLW-027-cicd.md`.

**No tests or CI existed before this.** Adds both, plus OIDC-authed deploy on merge.

## What's here
- **53 unit tests** (`node --test`, zero deps) over the pure logic: NWS day-pairing/glyphs/rain-soon, alert normalization, the Colorado cascade (net-flow, %full, vs-history), and the rain-state debounce. `npm test`.
- **`.github/workflows/ci.yml`** — runs on every PR, **no AWS creds**: unit tests · `node --check` syntax · secret scan (30+ hex in added lines; `ci-allow-hex` exempts reviewed constants) · service-worker cache-bump check · `sam validate --lint`.
- **`.github/workflows/deploy.yml`** — on push to `main`, path-filtered: **site** (`s3 sync web/` + CloudFront invalidation, us-east-1) when `web/` changed; **ingest** (`sam build && sam deploy`, us-west-2) when `ingest/src`/`template.yaml`/`samconfig.toml` changed. The NoEcho station + WU keys are read back from the live read Lambda in-job, so they never touch GitHub and a redeploy can't wipe them.
- **`infra/github-oidc.yaml`** + `infra/README.md` — one-time OIDC provider + `havasu-github-deploy` role, trust locked to `repo:cwoskoski/havasulakeweather:ref:refs/heads/main`. No long-lived keys in GitHub; role ARN hardcoded in the workflow.
- `samconfig.toml` `[ci]` deploy env (no `profile` → OIDC creds); `export` on `netFlow`/`pctFull`/`contextFor` for tests; CLAUDE.md CI/CD section + deploy-model note.

## ⚠️ Operating-model change
**Merging to `main` now deploys automatically** — the deploy gate becomes the merge itself (your call). Manual `sam deploy` / `s3 sync` stay as the fallback/bootstrap.

## Rollout (each step is yours)
1. Review this PR. CI should go green on it.
2. **Bootstrap OIDC once** (an AWS change): `aws cloudformation deploy … infra/github-oidc.yaml` — see `infra/README.md`. Until the role exists, the deploy jobs fail harmlessly at the auth step.
3. **Then merge.** This PR changes `ingest/src/water.js` (added `export`s — behavior-neutral) → the **ingest** job will deploy the read Lambda; no `web/` change → site job skipped.

I won't merge or bootstrap OIDC — both are yours.