### PR TITLE
chore: fix OIDC deploy-role trust (HLW-027 follow-up)

### DIFF
--- a/.github/workflows/oidc-debug.yml
+++ b/.github/workflows/oidc-debug.yml
@@ -1,0 +1,27 @@
+name: OIDC Debug
+
+# Manual-only. Prints the OIDC token claims GitHub sends to AWS so we can match the
+# deploy role's trust policy exactly. Does NOT touch AWS. Delete once the trust is set.
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  claims:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decode OIDC token claims (audience sts.amazonaws.com)
+        run: |
+          jwt="$(curl -sS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sts.amazonaws.com" | jq -r '.value')"
+          python3 - "$jwt" <<'PY'
+          import sys, base64, json
+          payload = sys.argv[1].split('.')[1]
+          payload += '=' * (-len(payload) % 4)
+          d = json.loads(base64.urlsafe_b64decode(payload))
+          for k in ("iss", "aud", "sub", "repository", "repository_owner", "ref", "workflow", "event_name"):
+              print(f"{k} = {d.get(k)}")
+          PY

--- a/infra/github-oidc.yaml
+++ b/infra/github-oidc.yaml
@@ -6,16 +6,15 @@ Description: >
   long-lived AWS keys stored in GitHub. Deploy ONCE — see infra/README.md.
 
 Parameters:
-  GitHubOwner:
+  GitHubSubClaim:
     Type: String
-    Default: cwoskoski
-  GitHubRepo:
-    Type: String
-    Default: havasulakeweather
-  GitHubBranch:
-    Type: String
-    Default: main
-    Description: Only this branch may assume the role (deploys run on push to main).
+    Default: "repo:cwoskoski/havasulakeweather:*"
+    Description: >
+      OIDC `sub` the role trusts (StringLike). Repo-scoped by default: only workflows
+      running in THIS repo can present a matching subject (fork PRs get a different
+      repo: prefix and can't assume it). Deploys stay main-only via the workflow's
+      `on: push: branches:[main]` trigger. Tighten to
+      "repo:OWNER/REPO:ref:refs/heads/main" once the exact push subject is confirmed.
   CreateOIDCProvider:
     Type: String
     AllowedValues: ["true", "false"]
@@ -62,7 +61,7 @@ Resources:
               StringEquals:
                 token.actions.githubusercontent.com:aud: sts.amazonaws.com
               StringLike:
-                token.actions.githubusercontent.com:sub: !Sub "repo:${GitHubOwner}/${GitHubRepo}:ref:refs/heads/${GitHubBranch}"
+                token.actions.githubusercontent.com:sub: !Ref GitHubSubClaim
       Policies:
         - PolicyName: havasu-deploy
           PolicyDocument:


### PR DESCRIPTION
Deploy job failed at `configure-aws-credentials` with `Not authorized to perform sts:AssumeRoleWithWebIdentity` despite a correct-looking trust + provider. This broadens the trust `sub` to `repo:cwoskoski/havasulakeweather:*` (repo-scoped; already redeployed to the live stack) and adds a manual `OIDC Debug` workflow to print the exact token claims so the trust can be matched precisely. Merging does not deploy (only `infra/` + a workflow file change).