### PR TITLE
HLW-029..041: impact-ranked feature backlog (13 tickets from competitive research)

### DIFF
--- a/docs/issues/HLW-029-lake-score.md
+++ b/docs/issues/HLW-029-lake-score.md
@@ -1,0 +1,57 @@
+# HLW-029: Lake Conditions Score — composite go/no-go for boating & swimming
+
+- **Status:** proposed
+- **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/58
+- **Branch:** `feat/HLW-029-lake-score`
+- **PR:** —
+- **Created:** 2026-08-23
+- **Impact rank:** 1 of 13 (feature-research backlog, see HLW-029…041)
+
+## Summary
+
+A single 0–100 **"Lake Score"** on the home page that answers the question every visitor
+actually has — *"is it a good day to be on the water?"* — computed from data we already
+ingest: our station's wind/gusts/temp/UV, NWS alerts, and USGS water temp.
+
+## Motivation / context
+
+- Competitive research (2026-08-23) found our closest direct competitor,
+  **havasu.info/lake-conditions.html**, already ships a 0–100 "Boating Safety Score"
+  (wind + gusts + water temp + air temp; 80+ excellent … <40 stay off) built on the
+  *same free stack* we use (USBR RISE + NWS airport obs), updating every 30–60 min.
+- Our durable edge: an **on-lake PWS updating every minute** — hyperlocal live wind is
+  exactly what wind apps (FishWeather/SailFlow) charge for. A score computed from it is
+  both better and more honest than theirs.
+- "Activity indices" (good day for X) are a top differentiator across the big apps
+  (TWC Activities, AccuWeather lifestyle indices); ours maps directly to boating/swimming.
+
+## Plan
+
+- [ ] Define the scoring formula in a pure helper (`ingest/src/` so it's unit-testable):
+      inputs = sustained wind, gusts, air temp, water temp, UV, active wind/storm alerts.
+      Piecewise bands, documented weights; output `{ score, band, factors[] }` where
+      `factors` explains the biggest detractors ("gusts 28 mph −35").
+- [ ] Two framings from one formula: **Boating** (wind/gust dominated) and **Swimming**
+      (water temp/UV/air dominated). Decide at design time whether to show one or both.
+- [ ] Serve via `/api/current` (or a tiny `/api/score`) so the formula stays server-side
+      and consistent; add `?mock=` scenarios covering each band.
+- [ ] Home page: score badge near the hero (number + band label + top factor), tap/click
+      expands the factor breakdown. SW cache bump.
+- [ ] Unit tests for band edges + factor attribution (`npm test`).
+
+## Acceptance criteria
+
+- [ ] Score renders on the home page with band label and at least one plain-language factor.
+- [ ] Score degrades gracefully when an input is stale/missing (drops the factor, notes it).
+- [ ] Wind advisory / storm alert forces the boating band down (never "excellent" during a
+      Lake Wind Advisory).
+- [ ] Mock scenarios exercise excellent / fair / poor / stay-off bands.
+- [ ] Formula covered by unit tests; no new external data sources, no new secrets.
+
+## Notes
+
+- Effort: **low** — pure arithmetic on data already flowing.
+- Related: HLW-032 (advisory banner) feeds the alert input; HLW-035 (swimmability) shares
+  the water-temp bands — build the bands once.
+- Research: havasu.info score bands; MarineWays publishes a similar boating report for
+  Lake Havasu City. Neither has on-lake wind.

--- a/docs/issues/HLW-030-records-almanac.md
+++ b/docs/issues/HLW-030-records-almanac.md
@@ -1,0 +1,57 @@
+# HLW-030: Station records & almanac — today vs. month / year / all-time
+
+- **Status:** proposed
+- **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/59
+- **Branch:** `feat/HLW-030-records-almanac`
+- **PR:** —
+- **Created:** 2026-08-23
+- **Impact rank:** 2 of 13 (feature-research backlog)
+
+## Summary
+
+Put our stored observation history to work: daily/monthly/yearly/all-time highs & lows
+("records since the station went live"), a **records snapshot widget** on the home page,
+and a "this day last year" context line. This is the defining feature family of the
+community-weather-site genre, and it's computable entirely from our own DynamoDB data.
+
+## Motivation / context
+
+- Research (2026-08-23): the records hierarchy (today / this month / this year / all-time)
+  is effectively the **genre standard** — it's the CumulusMX default menu, WeeWX ships
+  NOAA-style summaries out of the box, and the modern benchmark (Belchertown skin) puts a
+  "record snapshots" widget on the homepage rather than burying it.
+- The big apps monetize exactly this ("today vs. average" in Apple, Carrot Time Travel);
+  WU's per-station almanac is its stickiest surviving feature.
+- It compounds: every month the station runs, the records get more interesting — and it's
+  the base layer for HLW-031 (rain tracker) and HLW-040 (climate reports).
+
+## Plan
+
+- [ ] **Daily aggregates**: a scheduled job (or on-ingest rollup) writing one compact
+      daily-summary item per day — hi/lo temp (+times), max gust, rain total, avg wind,
+      pressure range — under a new `pk = DAY#<stationId>#YYYY` layout. Backfill from the
+      existing `OBS#` months on first run.
+- [ ] **Records materialization**: from the daily items, precompute month / year / all-time
+      records into a small static JSON (same pattern as HLW-018's `water-history.json` —
+      no request-time scans).
+- [ ] **`/api/records`** (or extend `/api/current`): today's hi/lo so far + current
+      month/year/all-time records + this-day-last-year values.
+- [ ] **Home page**: records-snapshot card ("Today 71–104°. Hottest Aug 23 on record: 111°
+      (2025)"); "this day last year" one-liner. SW bump.
+- [ ] Unit tests for the aggregation + record-comparison helpers.
+
+## Acceptance criteria
+
+- [ ] Daily summaries exist for the station's full history (backfilled) and accrue daily.
+- [ ] Records widget shows today vs. month/year/all-time with correct tie/record handling
+      (a new record labels itself as such).
+- [ ] "This day last year" renders when data exists; hidden cleanly when not.
+- [ ] No request-time table scans; DynamoDB cost delta ~zero (one item/day + static JSON).
+- [ ] Helpers unit-tested; mock scenarios for record / non-record days.
+
+## Notes
+
+- Effort: **medium** — new aggregation job + backfill, but simple math throughout.
+- Honesty rule: label everything "since <station start month/year>" — never imply
+  climate-period records. (Official normals could come later via free NOAA ACIS.)
+- Dependency for: HLW-031 (rain counters), HLW-040 (wind rose / monthly reports).

--- a/docs/issues/HLW-031-rain-tracker.md
+++ b/docs/issues/HLW-031-rain-tracker.md
@@ -1,0 +1,49 @@
+# HLW-031: Rain tracker — days since rain, rain days this year, monsoon season-to-date
+
+- **Status:** proposed
+- **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/60
+- **Branch:** `feat/HLW-031-rain-tracker`
+- **PR:** —
+- **Created:** 2026-08-23
+- **Impact rank:** 3 of 13 (feature-research backlog)
+
+## Summary
+
+Desert-flavored rain accounting: a **"days since measurable rain"** counter, rain-days-
+this-year, and a **monsoon season-to-date** total (Jun 15 – Sep 30) with last-season /
+prior-year comparison as history accrues. Extends the existing "is it raining right now?"
+answer with the question locals ask the rest of the year: *"when did it last rain, and
+how's the monsoon doing?"*
+
+## Motivation / context
+
+- Research (2026-08-23): on desert-Southwest community weather sites, the days-since-rain
+  counter + rain-season tracker is the single most-cited **favorite feature** (Saratoga
+  template "rain season / drought" plugin; NWS Tucson & CLIMAS monsoon trackers that
+  hobbyist sites embed). It's cheap, legible, and a conversation piece.
+- We already lead the page with "Is it raining in Havasu Lake right now?" — this makes the
+  answer interesting on the ~350 days/yr when it's "no".
+
+## Plan
+
+- [ ] Define "measurable rain" (≥ 0.01 in/day) in a pure helper; unit-test the edge cases
+      (trace amounts, day boundaries in local time).
+- [ ] From HLW-030's daily aggregates: last-rain date/amount, days-since counter,
+      rain-days YTD, calendar-year total, monsoon window total (Jun 15 – Sep 30).
+- [ ] Expose via `/api/records` (or the rain section of `/api/current`).
+- [ ] Home page rain card: "Last rain: Aug 2 (0.24″) — **21 days ago**. Monsoon so far:
+      1.10″." Prior-year comparison line once ≥ 2 seasons of data exist. SW bump.
+- [ ] Mock scenarios: raining now / rained yesterday / long dry spell / off-season.
+
+## Acceptance criteria
+
+- [ ] Counter is correct across midnight and month boundaries (station-local time).
+- [ ] Monsoon total resets on Jun 15 and freezes after Sep 30, labeled with the window.
+- [ ] Off-season (Oct–Jun 14) shows year totals instead of an empty monsoon line.
+- [ ] All helpers unit-tested; no new data sources.
+
+## Notes
+
+- Effort: **low** once HLW-030's daily aggregates exist (hard dependency).
+- Monsoon window Jun 15 – Sep 30 is the NWS definition for the Southwest.
+- Later garnish: per-storm totals and a rainfall calendar view (genre staples, not v1).

--- a/docs/issues/HLW-032-lake-wind-advisory.md
+++ b/docs/issues/HLW-032-lake-wind-advisory.md
@@ -1,0 +1,52 @@
+# HLW-032: Surface Lake Wind Advisories as a distinct boater warning
+
+- **Status:** proposed
+- **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/61
+- **Branch:** `feat/HLW-032-lake-wind-advisory`
+- **PR:** —
+- **Created:** 2026-08-23
+- **Impact rank:** 4 of 13 (feature-research backlog)
+
+## Summary
+
+When NWS issues a **Lake Wind Advisory** (the inland-lake equivalent of a small-craft
+advisory), present it as a distinct, boater-styled banner — not just another line in the
+generic alerts list. Presentation-only change on data we already fetch.
+
+## Motivation / context
+
+- Research (2026-08-23): NWS Las Vegas issues Lake Wind Advisories for the lake zone
+  (AZ zone **AZZ002 "Lake Havasu and Fort Mohave"** covers the lake surface) and even
+  maintains a Lake Havasu recreation forecast page (weather.gov/vef/RecHV). No consumer
+  app gives this advisory lake-specific prominence — it's free differentiation and a
+  genuine safety feature for the community.
+- We already consume `/api/alerts`; this is labeling + styling, plus one verification
+  task about zones.
+
+## Plan
+
+- [ ] **Verify zone coverage**: confirm which zone(s) our alerts point-query returns for
+      the CA-side community, and whether Lake Wind Advisories for the lake surface arrive
+      via that point or only via AZZ002. If needed, additionally poll the AZZ002 zone feed
+      in the read Lambda (still api.weather.gov, still free).
+- [ ] Classify alert types in a pure helper: Lake Wind Advisory / wind-related warnings →
+      "boater warning" class; unit-test with real CAP payloads.
+- [ ] Home page + `/water`: distinct banner (wind icon, "Boaters: Lake Wind Advisory until
+      7 PM") ahead of the generic alert list; respects the HLW-025 dismissal-persistence
+      behavior. SW bump.
+- [ ] `?mockAlerts=` scenario for the advisory.
+- [ ] Feed the advisory state into HLW-029's score as the alert input (if that ships first,
+      wire it; otherwise note the interface).
+
+## Acceptance criteria
+
+- [ ] An active Lake Wind Advisory renders the boater banner on home and `/water`.
+- [ ] Generic alerts are unaffected; dismissal persistence still works.
+- [ ] Zone verification documented in this ticket (which zone, which query).
+- [ ] Mock scenario demonstrates the banner without a live advisory.
+
+## Notes
+
+- Effort: **very low** (barring zone surprises). Highest safety-value-per-line-of-code
+  item in the backlog.
+- Link weather.gov/vef/RecHV from `/water` as a "more" reference (zero-cost credibility).

--- a/docs/issues/HLW-033-webcam.md
+++ b/docs/issues/HLW-033-webcam.md
@@ -1,0 +1,53 @@
+# HLW-033: Lake webcam (blocked: hardware / partner decision)
+
+- **Status:** proposed (blocked — needs a camera decision before any build)
+- **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/62
+- **Branch:** `feat/HLW-033-webcam`
+- **PR:** —
+- **Created:** 2026-08-23
+- **Impact rank:** 5 of 13 (feature-research backlog) — highest-impact single feature if
+  shipped, ranked here only because it's hardware-gated
+
+## Summary
+
+A live lake view (still refreshed every few minutes, later timelapse) on the home page.
+Research is unanimous that a webcam is the biggest single "is it worth driving out?"
+feature a lake site can have — and the one thing no data API can substitute for.
+
+## Motivation / context
+
+- Research (2026-08-23): webcams anchor every successful lake-community site
+  (golakehavasu's cam is its most-visited page-element; Windy integrates 55K cams as a
+  headline feature; AWN sells camera tiers). For a lake 40 min from anywhere, "what does
+  it look like right now" is the killer question.
+- Nothing on the CA side of the lake publishes a cam today — clear open niche.
+
+## Decision needed (blocking)
+
+Pick one before any implementation:
+
+1. **Own hardware** — an outdoor PoE/WiFi cam at Chad's site pushing stills. Full control,
+   ongoing power/mount/dust/heat considerations (Mojave summers).
+2. **Partner cam** — marina / store / resident hosts a cam we operate, or re-embed an
+   existing cam with written permission.
+3. **Defer** — park the ticket until 1 or 2 is workable.
+
+## Plan (sketch — refine after the decision)
+
+- [ ] Camera captures a still every 2–5 min → upload to the site S3 bucket
+      (`/cam/latest.jpg` + timestamped copies for timelapse).
+- [ ] Serve via the existing CloudFront distribution; short TTL on `latest.jpg`.
+- [ ] Home page card with timestamp + staleness indicator; graceful "cam offline" state.
+- [ ] Later: nightly timelapse assembly (Lambda + ffmpeg layer), archive retention policy.
+- [ ] Privacy check: field of view avoids identifiable private property/people.
+
+## Acceptance criteria
+
+- [ ] Live still on the home page, ≤ 5 min old, with visible capture time.
+- [ ] Offline state degrades cleanly (no broken image).
+- [ ] Monthly AWS cost delta estimated and accepted before deploy (storage + egress).
+
+## Notes
+
+- Effort: **medium** software, but blocked on hardware; revisit when a camera path exists.
+- S3 + CloudFront already in place — the pipeline is genuinely small once a camera exists.

--- a/docs/issues/HLW-034-water-yoy.md
+++ b/docs/issues/HLW-034-water-yoy.md
@@ -1,0 +1,48 @@
+# HLW-034: /water year-over-year — "this date across past years"
+
+- **Status:** proposed
+- **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/63
+- **Branch:** `feat/HLW-034-water-yoy`
+- **PR:** —
+- **Created:** 2026-08-23
+- **Impact rank:** 6 of 13 (feature-research backlog)
+
+## Summary
+
+Add a compact **"Aug 23 across the years"** view to `/water`: today's storage vs. the
+same calendar date for the past ~10 years, plus a one-line "vs. a year ago" delta.
+Extends HLW-018's percentile callout with the concrete year-list framing people quote
+to each other.
+
+## Motivation / context
+
+- Research (2026-08-23): water-data.com's **"last 10 of today's date"** table is the
+  benchmark presentation in the reservoir-tracking space, and DesertUSA leads with
+  "down X ft from a year ago". Percentiles (which we have from HLW-018) tell you *rank*;
+  the year list tells you *story* ("higher than 2022–2024, still below 2019").
+- We already hold ~90 years of daily storage/releases in DynamoDB (HLW-017) — this is a
+  presentation-layer win on sunk data-engineering cost.
+
+## Plan
+
+- [ ] Extend `build-history-stats.mjs` to also emit a small per-date structure (current
+      month is enough: for each of the last 10 years, storage on this calendar date) —
+      or compute date-values at build time into `water-history.json`. Keep the
+      no-request-time-scan rule.
+- [ ] `/api/water`: add `yoy` block — `{ lastYearDelta, years: [{year, value}, …] }`.
+- [ ] `/water` Lake Havasu card: "vs. a year ago: −13,200 af" line + tap-to-expand
+      10-year mini-table (or tiny bar strip). SW bump.
+- [ ] `?mockWater=` scenario covering higher / lower / mixed year patterns.
+- [ ] Unit test the date-alignment helper (leap days, missing days → nearest-day rule).
+
+## Acceptance criteria
+
+- [ ] "/water" shows the vs-last-year delta and a 10-year same-date comparison.
+- [ ] Missing historical days handled by a documented nearest-day rule, not blanks.
+- [ ] Static-file lookup only; no new scheduled jobs or data sources.
+- [ ] Helper unit-tested; mock path renders all branches.
+
+## Notes
+
+- Effort: **low** — data already stored (HLW-017), stats pipeline already exists (HLW-018).
+- Keep storage (acre-feet) as the metric, consistent with HLW-018's framing decision.

--- a/docs/issues/HLW-035-swimmability.md
+++ b/docs/issues/HLW-035-swimmability.md
@@ -1,0 +1,49 @@
+# HLW-035: Water-temp swimmability framing on /water and home
+
+- **Status:** proposed
+- **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/64
+- **Branch:** `feat/HLW-035-swimmability`
+- **PR:** —
+- **Created:** 2026-08-23
+- **Impact rank:** 7 of 13 (feature-research backlog)
+
+## Summary
+
+Frame the USGS water temperature we already display as an answer: **"Is the water
+swimmable?"** — comfort bands (cold-water caution / brisk / comfortable / bath-warm)
+plus seasonal context ("typical for late August: 82–86°F") from stored water data.
+
+## Motivation / context
+
+- Research (2026-08-23): LakeMonster and seatemperature.net both monetize "swimmability"
+  framing; lake-community sites (Watauga, Keuka) present water temp with seasonal-range
+  context as prominently as air temp. A number alone ("78°F") makes visitors do the
+  interpretation — the site should do it for them.
+- Cold-water safety is real content, not filler: sustained immersion below ~70°F carries
+  documented cold-shock/swim-failure risk (National Center for Cold Water Safety) —
+  worth a caution badge in winter/spring.
+
+## Plan
+
+- [ ] Define bands in a pure helper (shared with HLW-029's swimming score input):
+      < 60 dangerous-cold · 60–70 cold-water caution · 70–78 brisk · 78–85 comfortable ·
+      > 85 very warm. Cite the <70 caution source in code comment.
+- [ ] Seasonal context: monthly typical range from our stored water history (HLW-015/017
+      data; same static-stats pattern as HLW-018).
+- [ ] `/api/water`: add `{ band, label, monthTypical: {lo, hi} }` to the water-temp block.
+- [ ] `/water` + home-page water tile: band label + seasonal line; caution badge styling
+      for the two cold bands. SW bump.
+- [ ] `?mockWater=` scenarios for each band.
+
+## Acceptance criteria
+
+- [ ] Water temp shows a band label everywhere it appears, consistent between pages.
+- [ ] Cold bands (< 70°F) render a visually distinct caution treatment.
+- [ ] Seasonal "typical for <month>" line appears when history exists for that month.
+- [ ] Band helper unit-tested at every boundary; mocks cover all bands.
+
+## Notes
+
+- Effort: **low**. Band thresholds are a product decision — confirm the numbers above
+  at plan-approval time.
+- Shared bands with HLW-029 (swim score) — implement once, import twice.

--- a/docs/issues/HLW-036-threshold-alerts.md
+++ b/docs/issues/HLW-036-threshold-alerts.md
@@ -1,0 +1,57 @@
+# HLW-036: Threshold alerts — wind (and later lake level) push notifications
+
+- **Status:** proposed
+- **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/65
+- **Branch:** `feat/HLW-036-threshold-alerts`
+- **PR:** —
+- **Created:** 2026-08-23
+- **Impact rank:** 8 of 13 (feature-research backlog)
+
+## Summary
+
+Let visitors opt into **push alerts from our own station**: "notify me when sustained
+wind tops 15 mph" (boaters' #1 ask), later lake-level / release-change thresholds.
+The PWA is already installed on users' phones — this is the feature that makes it
+indispensable rather than a bookmark.
+
+## Motivation / context
+
+- Research (2026-08-23): configurable threshold alerts are the stickiest feature across
+  three separate genres — wind apps (WindAlert/FishWeather), river apps (RiverApp's core
+  feature), and station networks (Ambient **paywalls** SMS alerts behind AWN+). Nobody
+  offers them for this lake from an on-lake station. Free push = clear differentiation.
+- Recurring-visit driver: an alert subscription converts a occasional visitor into a
+  daily relationship with the site.
+
+## Plan
+
+- [ ] **Phase 0 (zero-infra, ship immediately):** "Get level alerts" link on `/water`
+      deep-linking USGS WaterAlert (free email/SMS on the Havasu gauge) with a one-line
+      how-to. Zero build cost, real value.
+- [ ] **Phase 1 (wind push, our infra):** Web Push — VAPID keypair (new NoEcho SAM
+      params), subscription endpoint on the read/ingest Lambda storing subscriptions +
+      chosen threshold in DynamoDB, and a check on station ingest (already fires every
+      minute) that sends pushes on upward threshold crossings with a cooldown
+      (e.g. ≥ 2 h between alerts per subscriber).
+- [ ] UI: alert bell on the home page — pick threshold (10/15/20/25 mph), permission
+      flow, manage/unsubscribe. iOS requires the PWA installed to Home Screen for push —
+      detect and explain. SW push handler + cache bump.
+- [ ] Unit tests: crossing detection, cooldown, hysteresis (no flapping at the threshold).
+- [ ] Cost/abuse review before deploy: subscription table TTL for dead endpoints,
+      per-send error pruning (410 Gone → delete).
+
+## Acceptance criteria
+
+- [ ] Phase 0 link live on `/water`.
+- [ ] A subscribed device receives a push within one ingest cycle of a threshold crossing.
+- [ ] No repeat alert within the cooldown; dropping below and re-crossing after cooldown
+      re-alerts.
+- [ ] Unsubscribe works and dead subscriptions are pruned automatically.
+- [ ] Secrets (VAPID private key) handled as NoEcho params; costs estimated and accepted.
+
+## Notes
+
+- Effort: **high** (the only ticket touching ingest, storage, SW, and UI at once) —
+  which is why it ranks below cheaper wins despite top-tier stickiness.
+- Later phases: lake-level and scheduled-release-change alerts reuse the same pipeline
+  (HLW-038 would feed the latter).

--- a/docs/issues/HLW-037-sun-moon-solunar.md
+++ b/docs/issues/HLW-037-sun-moon-solunar.md
@@ -1,0 +1,50 @@
+# HLW-037: Sun & moon upgrade — moon phase, day-length delta, solunar bite times
+
+- **Status:** proposed
+- **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/66
+- **Branch:** `feat/HLW-037-sun-moon-solunar`
+- **PR:** —
+- **Created:** 2026-08-23
+- **Impact rank:** 9 of 13 (feature-research backlog)
+
+## Summary
+
+Extend the HLW-021 sun arc into a full sun & moon card: **moon phase + moonrise/set**,
+a day-length delta ("1 m 48 s shorter than yesterday"), and **solunar fishing times**
+(major/minor bite windows). All pure client-side astronomy — no API, no backend.
+
+## Motivation / context
+
+- Research (2026-08-23): moon phase is near-universal (every major app); the day-length
+  delta is a beloved small touch in the PWS-site genre (Saratoga/Belchertown); and
+  solunar bite times are the free version of what Fishbrain sells as "BiteTime".
+  Anglers are a core audience for this lake — solunar majors/minors (moon transit /
+  moon-underfoot ± ~1 h; minors at moonrise/set) are a standard published calculation.
+- HLW-021 already established the client-side-astronomy pattern; this is more of the same.
+
+## Plan
+
+- [ ] Add moon math to the existing client-side astronomy code (or vendor a small
+      suncalc-style lib into `web/vendor/`): phase + illumination %, moonrise/set,
+      transit/underfoot times. No network calls.
+- [ ] Day-length delta vs. yesterday, computed locally.
+- [ ] Solunar card: today's two majors + two minors as time ranges, phase-aware quality
+      hint (new/full = stronger); label it plainly as the traditional solunar theory.
+- [ ] Placement: extend the sun-arc card on home; fuller version could live on `/water`
+      (fishing context). SW bump.
+- [ ] Unit-test the astronomy helpers against published ephemeris values for Havasu Lake's
+      coordinates (a few known dates).
+
+## Acceptance criteria
+
+- [ ] Moon phase + rise/set correct for the site's lat/lon vs. published values (± a few
+      minutes).
+- [ ] Day-length delta matches yesterday-vs-today sunrise/sunset math.
+- [ ] Solunar majors/minors render for today with sensible ranges; date rollover works.
+- [ ] Zero new network requests; works offline once cached.
+
+## Notes
+
+- Effort: **low-medium** (math + tests, no infra).
+- Related: HLW-021 (sun arc — extend, don't duplicate). Solunar feeds a future fishing
+  framing on `/water`.

--- a/docs/issues/HLW-038-scheduled-releases.md
+++ b/docs/issues/HLW-038-scheduled-releases.md
@@ -1,0 +1,49 @@
+# HLW-038: Scheduled dam releases — what Parker/Davis will do today & tomorrow
+
+- **Status:** proposed
+- **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/67
+- **Branch:** `feat/HLW-038-scheduled-releases`
+- **PR:** —
+- **Created:** 2026-08-23
+- **Impact rank:** 10 of 13 (feature-research backlog)
+
+## Summary
+
+Show **scheduled** hourly releases for Parker and Davis dams (today/tomorrow) on
+`/water`, alongside the observed releases we already display. Anglers, paddlers, and
+shoreline users care about what the river is *about to do*, and almost no third-party
+site surfaces the schedule.
+
+## Motivation / context
+
+- Research (2026-08-23): USBR's Lower Colorado river-ops pages publish next-day hourly
+  release schedules (usbr.gov/lc/riverops.html) — flagged as the notable dataset most
+  aggregators skip. Our `/water` page already tells the observed-flow story (HLW-002,
+  HLW-013/014); the schedule completes it ("release ramps to 8,000 cfs at 6 AM").
+
+## Plan
+
+- [ ] **Data recon first** (research task inside this ticket): find the machine-readable
+      form — check whether RISE exposes schedule datasets, and what format the riverops
+      "Real-Time Operations Outlook" / Parker automated report actually serve (JSON, CSV,
+      HTML). Decide fetch strategy + failure posture. If it's scrape-only HTML, weigh
+      fragility before committing (this ticket dies gracefully if there's no stable feed).
+- [ ] Fetch in the existing water ingest path (or read-Lambda with caching), normalized to
+      `{ dam, hours: [{t, cfs}] }` for today + tomorrow.
+- [ ] `/api/water`: `scheduled` block; `/water` flow card gets a small "scheduled" strip
+      (peak, ramp times) — not a full chart in v1. SW bump.
+- [ ] `?mockWater=` schedule scenarios (steady / morning ramp / weekend low).
+- [ ] Unit tests for the parser/normalizer.
+
+## Acceptance criteria
+
+- [ ] Recon documented here: source, format, stability assessment, go/no-go.
+- [ ] (If go) `/water` shows today's + tomorrow's scheduled peak and ramp windows per dam.
+- [ ] Source outage degrades to the current observed-only view — no broken card.
+- [ ] Parser unit-tested against captured fixtures.
+
+## Notes
+
+- Effort: **medium**, dominated by the recon and parser-robustness work.
+- Pairs with HLW-036 later ("alert me when tomorrow's schedule jumps").
+- Attribution + "provisional, schedules change" disclaimer required.

--- a/docs/issues/HLW-039-daily-summary.md
+++ b/docs/issues/HLW-039-daily-summary.md
@@ -1,0 +1,54 @@
+# HLW-039: Plain-language daily summary ("today at the lake")
+
+- **Status:** proposed
+- **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/68
+- **Branch:** `feat/HLW-039-daily-summary`
+- **PR:** —
+- **Created:** 2026-08-23
+- **Impact rank:** 11 of 13 (feature-research backlog)
+
+## Summary
+
+One templated sentence-or-two at the top of the home page that reads the day for you:
+*"Hot and calm this morning — 104° by 3 PM, gusts to 22 mph after noon, lake 82°.
+Good morning to be on the water."* Deterministic template over data we already have —
+no LLM, no new costs.
+
+## Motivation / context
+
+- Research (2026-08-23): plain-language narratives are the 2025–26 frontier feature
+  (Pixel's on-device AI summary, Carrot's narrative, TWC's probabilistic stories), and
+  the NWS Area Forecast Discussion is the beloved original. A community site's version
+  doesn't need AI — a well-written rule-based template over local data reads just as
+  naturally and never hallucinates.
+- Synthesizes what we already show (station now + NWS hourly forecast + water temp +
+  score/advisories) into the one-glance answer casual visitors want.
+
+## Plan
+
+- [ ] Template engine as a pure helper: condition slots (heat band, wind arc through the
+      day from NWS hourly, rain chance, water temp, active advisories, score band) →
+      composed sentence(s). Rule table lives in code, unit-tested per branch.
+- [ ] Tone/style pass with Chad on ~10 sample days before shipping (the writing *is* the
+      feature).
+- [ ] Serve from the read Lambda (same inputs as `/api/current` + `/api/forecast`) so the
+      text is consistent for all visitors and cacheable.
+- [ ] Home page: summary line above the tiles; regenerates with normal data refresh.
+      SW bump. Mock scenarios for each major template branch.
+- [ ] Link "full forecast discussion" → NWS AFD (free, api.weather.gov product) for the
+      weather-curious.
+
+## Acceptance criteria
+
+- [ ] Summary renders for arbitrary current conditions without ungrammatical output
+      (unit tests cover branch combinations, including missing inputs).
+- [ ] Advisory days always mention the advisory first.
+- [ ] Chad has approved the voice on the sample set.
+- [ ] No new data sources, no per-request LLM/API costs.
+
+## Notes
+
+- Effort: **medium** — the engineering is easy; the copywriting and branch coverage are
+  the real work.
+- Dependencies: reads HLW-029's score and HLW-032's advisory class if present; works
+  without them.

--- a/docs/issues/HLW-040-wind-rose-climate-reports.md
+++ b/docs/issues/HLW-040-wind-rose-climate-reports.md
@@ -1,0 +1,47 @@
+# HLW-040: Wind rose + NOAA-style monthly climate reports
+
+- **Status:** proposed
+- **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/69
+- **Branch:** `feat/HLW-040-wind-rose-climate-reports`
+- **PR:** —
+- **Created:** 2026-08-23
+- **Impact rank:** 12 of 13 (feature-research backlog)
+
+## Summary
+
+Two enthusiast-grade almanac features from stored station data: a **wind rose**
+(direction/speed frequency, selectable period) and **monthly climate summary reports**
+(NOAA-style text/table: daily hi/lo/rain for the month, means, extremes).
+
+## Motivation / context
+
+- Research (2026-08-23): both are genre-standard credibility features on serious PWS
+  sites (WeeWX ships NOAA-format reports out of the box; wind roses are a Saratoga-
+  template staple). They signal "real station, real record" — the thing that separates
+  a community station from an app screenshot — and boaters actually read wind roses
+  (prevailing afternoon direction matters on this lake).
+
+## Plan
+
+- [ ] Wind rose: aggregate direction (16 sectors) × speed bins from stored obs — monthly
+      + yearly precomputed into the HLW-030 static-stats output; render as a small SVG
+      on a stats/almanac page (no chart library).
+- [ ] Monthly report: from HLW-030's daily aggregates, generate the classic table
+      (day, hi, lo, rain; monthly mean/max/min/total) as a page per month + plain-text
+      view; months are immutable once complete → build once, cache forever.
+- [ ] Navigation: an "Almanac" page linking records (HLW-030), reports, wind rose.
+      SW bump.
+- [ ] Unit tests for sector/bin math and report totals.
+
+## Acceptance criteria
+
+- [ ] Wind rose renders for month/year periods and matches hand-checked sector counts.
+- [ ] Every complete month since station start has a report page; current month says
+      "in progress".
+- [ ] Static/pregenerated output only — no request-time aggregation.
+
+## Notes
+
+- Effort: **medium**; hard dependency on HLW-030's daily aggregates and stats pipeline.
+- Ranked low on general-audience impact, high on credibility with the weather/boating
+  crowd — a good "polish era" ticket.

--- a/docs/issues/HLW-041-air-quality.md
+++ b/docs/issues/HLW-041-air-quality.md
@@ -1,0 +1,48 @@
+# HLW-041: Air quality tile (EPA AirNow) — smoke & dust awareness
+
+- **Status:** proposed
+- **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/70
+- **Branch:** `feat/HLW-041-air-quality`
+- **PR:** —
+- **Created:** 2026-08-23
+- **Impact rank:** 13 of 13 (feature-research backlog)
+
+## Summary
+
+An AQI tile on the home page fed by the free **EPA AirNow API** — mainly valuable on
+wildfire-smoke and blowing-dust days, which is when the community actually checks.
+
+## Motivation / context
+
+- Research (2026-08-23): AQI is now effectively table-stakes in every major weather app
+  (Apple, Google, TWC, AccuWeather all lead with it during smoke events). It's the only
+  table-stakes gap this site has. AirNow is the official free source (API key, no cost).
+- Honest caveat found in research: desert monitor coverage is sparse — the nearest
+  official monitors are likely Lake Havasu City / Parker, i.e. regional not hyperlocal.
+  Fine for smoke events (regional by nature), and we label the distance.
+
+## Plan
+
+- [ ] **Recon**: query AirNow for the site's lat/lon, record which monitor(s) respond and
+      their distance; decide labeling ("AQI — regional, from <monitor> Xmi away").
+      If coverage is unusable, evaluate PurpleAir (free key) as fallback and re-scope.
+- [ ] Fetch in the read Lambda with caching (AirNow updates hourly; cache ≥ 30 min to
+      stay far under rate limits). API key = new NoEcho SAM param, wired through the
+      CI deploy's read-back mechanism like the existing keys.
+- [ ] `/api/current` (or `/api/aqi`): `{ aqi, category, pollutant, monitor, distanceMi }`.
+- [ ] Home tile with EPA category color + label; hidden or "no data" state when the API
+      is down. `?mock=` scenarios per category. SW bump.
+- [ ] Unit test category mapping at the AQI breakpoints.
+
+## Acceptance criteria
+
+- [ ] Tile shows AQI + EPA category with correct color mapping at all breakpoints.
+- [ ] Monitor provenance/distance visible (tap or subtitle) — no false hyperlocal claim.
+- [ ] Key stored as NoEcho param; survives a CI redeploy via the parameter read-back.
+- [ ] API outage degrades cleanly; cache keeps us within AirNow limits.
+
+## Notes
+
+- Effort: **medium** (new external API + key plumbing).
+- Ranked last: real value is episodic (smoke days), and it's the only backlog item
+  needing a new external dependency + secret. Pollen: no viable free US API — skipped.

--- a/docs/research/2026-08-23-feature-landscape.md
+++ b/docs/research/2026-08-23-feature-landscape.md
@@ -1,0 +1,151 @@
+# Feature landscape research — weather apps, lake-data sites, community PWS sites
+
+**Date:** 2026-08-23 · **Purpose:** ground the HLW-029…041 backlog (issues #58–#70,
+PR #71) in what the market actually ships. Three parallel sweeps: major consumer
+weather apps/sites, lake & water-recreation sites, and the community
+personal-weather-station (PWS) site genre.
+
+## Where havasulakeweather.com stood at research time
+
+Live conditions (temp, wind/gust, humidity, dew point, pressure, UV, solar, rain),
+"is it raining right now?" answer, NWS forecast + alerts, temperature history chart,
+sunrise/sunset sun arc (HLW-021), station cross-check vs. nearby WU PWS, radar page,
+and `/water` (level & storage vs. ~90 yr history with percentile callout + decades
+sparkline (HLW-017/018), dam releases, water-routing explainer). PWA with SW caching.
+
+**Verdict:** table stakes are covered in every genre. The backlog is differentiation.
+
+## Key competitive fact
+
+**havasu.info/lake-conditions.html** is the closest direct competitor: live water/air
+temp, wind, lake elevation vs. 450 ft full pool, storage, outflow, 7-day forecast,
+sun/moon — built on the *same free stack* we use (USBR RISE + NWS airport obs,
+updating 30–60 min) — **plus a 0–100 composite "Boating Safety Score"**
+(wind + gusts + water temp + air temp; 80+ excellent … <40 stay off).
+
+Our durable advantages: an **on-lake PWS updating every minute** (hyperlocal live wind
+is what FishWeather/SailFlow sell), the CA-side community focus, and the installed PWA.
+
+## Genre 1 — major weather apps/sites
+
+Covered: Weather.com/TWC, AccuWeather, Weather Underground, Windy, Ventusky, Apple
+Weather, Google/Pixel Weather, Carrot, MyRadar, Mercury, Tempest, Ambient Weather
+Network, weather.gov.
+
+- **Table stakes:** feels-like + core metrics, hourly/10-day forecast, animated radar,
+  NWS alerts, sunrise/sunset, moon phase, AQI (US), multi-location, dark mode.
+- **Signature differentiators:**
+  - Minute-scale precip timing (AccuWeather MinuteCast, Apple next-hour) — **no free
+    data path**; skip.
+  - Plain-language/AI daily narratives (Pixel on-device AI, Carrot) — the 2025–26
+    frontier; NWS AFD is the free original. → HLW-039.
+  - Activity indices ("good day for golf/hiking") — maps to boating/swimming. → HLW-029.
+  - Historical framing ("vs. average", "this day last year", Carrot Time Travel, WU
+    almanac) — cheap if you retain obs, which we do. → HLW-030.
+  - Custom threshold alerts (Windy, AWN — AWN paywalls SMS behind AWN+). → HLW-036.
+  - Lightning proximity (AccuWeather network, Tempest hardware) — no free path;
+    HLW-022's WH31L remains the only route (blocked).
+  - Trip/route forecasting (Mercury, MyRadar RouteCast, iOS 26) — not our niche.
+- **weather.gov gaps others monetize:** dated UX, no push, no minute-cast, no PWS data —
+  the space a curated local site lives in.
+
+## Genre 2 — lake / river / water-recreation sites
+
+Covered: lakesonline/lakelevels network, water-data.com, USGS National Water
+Dashboard + WaterAlert, USBR riverops, LakeMonster, Fishbrain, FishWeather/SailFlow,
+Windfinder, NOAA/NWS lake products, Navionics, iBoating, WillyWeather, RiverApp, and
+Havasu-specific sites (havasu.info, golakehavasu, DesertUSA, AZGFD).
+
+- **Table stakes:** elevation vs. full pool with delta, historical level chart, water
+  temp, wind now + forecast, 7-day weather, attribution + timestamp. (All covered.)
+- **Differentiators worth stealing:**
+  - Composite go/no-go score (havasu.info) → HLW-029.
+  - Year-over-year date comparison (water-data.com's "last 10 of today's date";
+    DesertUSA "down X ft from a year ago") → HLW-034.
+  - Swimmability framing for water temp (LakeMonster, seatemperature.net; sustained
+    immersion <70 °F = documented cold-shock risk) → HLW-035.
+  - **Scheduled** next-day hourly dam releases (USBR riverops publishes; almost no
+    aggregator surfaces) → HLW-038.
+  - NWS **Lake Wind Advisory** — issued for the lake zone (AZZ002 "Lake Havasu and
+    Fort Mohave"); NWS Vegas also runs a Lake Havasu rec-forecast page
+    (weather.gov/vef/RecHV) → HLW-032.
+  - Solunar bite times (Fishbrain's paid "BiteTime"; the calculation is pure moon
+    astronomy) → HLW-037.
+  - Threshold alerts on level/flow (RiverApp's core feature; USGS WaterAlert free) →
+    HLW-036 phase 0.
+  - Webcam — the #1 "is it worth driving out" feature (golakehavasu, Windy's 55K cams)
+    → HLW-033 (hardware-gated).
+- **Not replicable free:** Fishbrain's catch-data network, LakeMonster's satellite
+  temp/clarity models, Navionics/iBoating bathymetry.
+- Possible later: **EPA CyAN** free satellite cyanobacteria (algal bloom) data covers
+  large reservoirs — not ticketed yet.
+
+## Genre 3 — community PWS sites (our genre)
+
+Covered: AWN/WU/WeatherLink/Tempest platform dashboards; Saratoga-template, WeeWX
+(Seasons + Belchertown), CumulusMX, Meteotemplate sites; desert-SW and lake-community
+independents (El Dorado Weather, Komoka, Watauga Lake, Keuka Lake).
+
+- **Genre-standard (ubiquitous):** records hierarchy — today / this month / this year /
+  all-time since station start (the CumulusMX menu is the de-facto spec); rain totals
+  day/month/year; per-sensor history graphs; NWS forecast; sun/moon; pressure trend.
+  → HLW-030 closes our biggest genre gap.
+- **Uncommon-but-loved:**
+  - Days-since-rain + rain-days-this-year + rain-season/monsoon tracker — *the*
+    signature desert-SW feature (Saratoga rain-season plugin; NWS monsoon window
+    Jun 15–Sep 30) → HLW-031.
+  - Homepage records widget (Belchertown "record snapshots") → HLW-030.
+  - Day-length delta, wind rose, NOAA-style monthly reports → HLW-037/040.
+  - Real-time no-reload updates, auto dark mode at sunset — polish ideas, not ticketed.
+- **Computable from our own DynamoDB history, no external API:** all records/almanac,
+  all rain accounting, wind rose, trend graphs, derived comfort values, sun/moon math.
+- Lake-community analogs (Watauga, Keuka) lead with water temp + webcam + boater wind
+  panel — matching our HLW-033/035 + existing wind emphasis.
+
+## Dead ends (no viable free data)
+
+Minute-cast precip timing · lightning proximity (without the WH31L, HLW-022) ·
+pollen (Google/Ambee APIs are paid; no free US source).
+
+## Resulting backlog (impact-ranked)
+
+| Rank | Ticket | Issue | Effort |
+|---|---|---|---|
+| 1 | HLW-029 Lake Conditions Score | #58 | low |
+| 2 | HLW-030 Records & almanac | #59 | medium |
+| 3 | HLW-031 Rain / monsoon tracker | #60 | low |
+| 4 | HLW-032 Lake Wind Advisory banner | #61 | very low |
+| 5 | HLW-033 Webcam | #62 | blocked: hardware |
+| 6 | HLW-034 /water year-over-year | #63 | low |
+| 7 | HLW-035 Swimmability framing | #64 | low |
+| 8 | HLW-036 Threshold alerts | #65 | high |
+| 9 | HLW-037 Sun & moon + solunar | #66 | low-med |
+| 10 | HLW-038 Scheduled dam releases | #67 | medium |
+| 11 | HLW-039 Plain-language daily summary | #68 | medium |
+| 12 | HLW-040 Wind rose + climate reports | #69 | medium |
+| 13 | HLW-041 AQI (EPA AirNow) | #70 | medium |
+
+Ranking = expected community impact, feasibility-adjusted (webcam would rank higher
+unblocked; threshold alerts rank below their stickiness because of infra effort).
+Dependencies: HLW-031 & 040 build on HLW-030's daily aggregates; HLW-029/032/035
+share bands/inputs (natural first arc: 029 → 032 → 035).
+
+## Free-data source map (for future tickets)
+
+| Need | Free source |
+|---|---|
+| Forecast, alerts, AFD, Lake Wind Advisory | api.weather.gov (in use) |
+| Lake elevation/storage/releases | USBR RISE (in use); riverops for *schedules* |
+| River flow / gauge / water temp | USGS NWIS (in use) |
+| Stage/flow forecasts, flood categories | NWPS — api.water.noaa.gov/nwps/v1 |
+| Level/flow threshold alerts (no build) | USGS WaterAlert |
+| Radar tiles | RainViewer free tier; NOAA WMS |
+| Multi-model forecasts | Open-Meteo (non-commercial) |
+| AQI | EPA AirNow (free key); PurpleAir fallback |
+| Sun/moon/solunar | pure astronomy math, no API |
+| Algal blooms | EPA CyAN |
+| Official climate normals | NOAA ACIS |
+| Fishing reports, ramp status | AZGFD (link/cite) |
+
+Full per-site inventories with source links live in the session transcript; the load-
+bearing facts are captured above and in the individual tickets.


### PR DESCRIPTION
Adds 13 proposed tickets (`docs/issues/HLW-029` … `HLW-041`) distilled from a competitive research sweep (2026-08-23) of major weather apps, lake/water-data sites, and community personal-weather-station sites. Docs-only — no site or infra changes; every ticket is `proposed` and awaits individual plan approval before any build.

Ranked most impactful → least (issue numbers follow rank):

| Rank | Ticket | Issue | Effort |
|---|---|---|---|
| 1 | HLW-029 Lake Conditions Score (boating/swimming go-no-go) | #58 | low |
| 2 | HLW-030 Station records & almanac | #59 | medium |
| 3 | HLW-031 Rain tracker (days-since-rain, monsoon-to-date) | #60 | low |
| 4 | HLW-032 Lake Wind Advisory boater banner | #61 | very low |
| 5 | HLW-033 Lake webcam | #62 | blocked: hardware |
| 6 | HLW-034 /water year-over-year comparison | #63 | low |
| 7 | HLW-035 Water-temp swimmability framing | #64 | low |
| 8 | HLW-036 Threshold alerts (wind push) | #65 | high |
| 9 | HLW-037 Sun & moon + solunar bite times | #66 | low-med |
| 10 | HLW-038 Scheduled Parker/Davis dam releases | #67 | medium |
| 11 | HLW-039 Plain-language daily summary | #68 | medium |
| 12 | HLW-040 Wind rose + monthly climate reports | #69 | medium |
| 13 | HLW-041 Air quality tile (EPA AirNow) | #70 | medium |

Ranking = expected impact on the lake community, feasibility-adjusted (webcam would rank higher if not hardware-gated; threshold alerts lower than their stickiness because of infra effort). Key research facts are embedded in each ticket; notable: havasu.info already ships a composite Boating Safety Score on our same free data stack — HLW-029 is the parity-plus answer using our on-lake station.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WpbFD88XQswDrScobUcao