### PR TITLE
HLW-028: SEO Phase 1 — subpage meta, schema, sitemap, footer nav

### DIFF
--- a/docs/issues/HLW-028-seo-improvements.md
+++ b/docs/issues/HLW-028-seo-improvements.md
@@ -1,6 +1,6 @@
 # HLW-028: SEO — get havasulakeweather.com ranking for local weather queries
 
-- **Status:** proposed
+- **Status:** in-progress — Phase 1 built + previewed (0 console errors), in PR
 - **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/56
 - **Branch:** `feat/HLW-028-seo` (Phase 1; later phases may use their own branches)
 - **PR:** <url>
@@ -30,17 +30,17 @@ duplicate `www` host, and `/water` (extensionless) returning a raw S3 403.
 
 ### Phase 1 — quick wins (`web/` only, rides normal CI/CD)
 
-- [ ] `web/sitemap.xml`: add `/water.html` + `/radar.html`; stamp `lastmod` in the deploy
-      workflow instead of hand-maintaining it (current value is stale).
-- [ ] `web/water.html` + `web/radar.html`: add canonical, OG/Twitter tags, an `<h1>`, and
-      BreadcrumbList JSON-LD. Retitle water page around "Lake Havasu Water Level, Dam
+- [x] `web/sitemap.xml`: added `/water.html` + `/radar.html` (lastmod set to the change
+      date, 2026-08-24). Deploy-workflow auto-stamp of `lastmod` deferred.
+- [x] `web/water.html` + `web/radar.html`: canonical, OG/Twitter tags, an `<h1>`, and
+      WebPage + BreadcrumbList JSON-LD. Water page retitled "Lake Havasu Water Level, Dam
       Releases & Water Temperature — Live (Havasu Lake, CA)".
-- [ ] Add "Havasu Landing" + "Colorado River" to homepage About copy and as
-      `Place.alternateName` in the JSON-LD; add `sameAs` (Wikipedia "Havasu Lake,
-      California", GNIS) to the `Place` node.
-- [ ] Static footer nav on all three pages with keyword anchors
+- [x] "Havasu Landing" + "Colorado River" added to homepage About copy and to
+      `Place.alternateName`; `sameAs` added — Wikipedia "Havasu Lake, California" +
+      Wikidata Q14682145 (which carries GNIS 1660731).
+- [x] Static footer nav on all three pages with keyword anchors
       ("Live conditions · Radar · Lake Havasu water level") — always visible, no JS gate.
-- [ ] Bump `web/sw.js` CACHE version.
+- [x] Bumped `web/sw.js` CACHE → v32.
 - [ ] No-code: verify Google Search Console + Bing Webmaster Tools, submit sitemap (Chad).
 
 ### Phase 2 — infra (`site-template.yaml`, separate approval)

--- a/docs/issues/HLW-028-seo-improvements.md
+++ b/docs/issues/HLW-028-seo-improvements.md
@@ -1,0 +1,87 @@
+# HLW-028: SEO — get havasulakeweather.com ranking for local weather queries
+
+- **Status:** proposed
+- **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/56
+- **Branch:** `feat/HLW-028-seo` (Phase 1; later phases may use their own branches)
+- **PR:** <url>
+- **Created:** 2026-08-23
+
+## Summary
+
+Act on the SEO audit (seo-specialist agent, 2026-08-23): the site currently sits ~page 5
+for "Havasu Lake weather". The homepage's on-page SEO is already strong; what's holding
+the site back is domain authority (zero backlinks), near-invisible subpages
+(`water.html`/`radar.html` lack canonical/OG/JSON-LD/h1 and aren't in the sitemap), a
+duplicate `www` host, and `/water` (extensionless) returning a raw S3 403.
+
+## Motivation / context
+
+- Competitors ranking above us for "Havasu Lake CA weather" (WeatherBug, Wunderground,
+  AccuWeather, Weather Network) serve generic model data for 92363 — a real local station
+  can beat them once Google trusts the domain.
+- "Havasu Landing weather" has **no dedicated result anywhere** and the phrase appears
+  nowhere on our site — most winnable keyword gap.
+- The water page targets our highest-volume winnable queries ("Lake Havasu water level",
+  "water temperature", "Parker Dam releases") and Google can barely see it.
+- Not chasing: "Lake Havasu City weather" (AZ head term, owned by majors); the CA/AZ
+  disambiguation copy still catches misrouted searchers.
+
+## Plan (phased; each phase = its own PR)
+
+### Phase 1 — quick wins (`web/` only, rides normal CI/CD)
+
+- [ ] `web/sitemap.xml`: add `/water.html` + `/radar.html`; stamp `lastmod` in the deploy
+      workflow instead of hand-maintaining it (current value is stale).
+- [ ] `web/water.html` + `web/radar.html`: add canonical, OG/Twitter tags, an `<h1>`, and
+      BreadcrumbList JSON-LD. Retitle water page around "Lake Havasu Water Level, Dam
+      Releases & Water Temperature — Live (Havasu Lake, CA)".
+- [ ] Add "Havasu Landing" + "Colorado River" to homepage About copy and as
+      `Place.alternateName` in the JSON-LD; add `sameAs` (Wikipedia "Havasu Lake,
+      California", GNIS) to the `Place` node.
+- [ ] Static footer nav on all three pages with keyword anchors
+      ("Live conditions · Radar · Lake Havasu water level") — always visible, no JS gate.
+- [ ] Bump `web/sw.js` CACHE version.
+- [ ] No-code: verify Google Search Console + Bing Webmaster Tools, submit sitemap (Chad).
+
+### Phase 2 — infra (`site-template.yaml`, separate approval)
+
+- [ ] CloudFront Function on default behavior: 301 `www` → apex; rewrite extensionless
+      paths (`/water` → `/water.html`); standardize canonicals/sitemap/internal links on
+      clean URLs.
+- [ ] `CustomErrorResponses`: 403 → `/404.html` with response code 404; add a simple
+      404 page.
+
+### Phase 3 — content (one PR per page/section)
+
+- [ ] Static water-temperature section on `/water` (USBR-sourced; incumbents are scraper
+      sites). Optional `Dataset` JSON-LD.
+- [ ] FAQ / disambiguation page: "Is Havasu Lake the same as Lake Havasu City?" + time
+      zone, lake level, location questions.
+- [ ] Monthly climate page ("Havasu Lake weather by month").
+
+### Phase 4 — ongoing (no code)
+
+- [ ] Local link building: Havasu Landing Resort & Casino, community Facebook groups,
+      weather-station directories (Ambient map, PWSweather, CWOP), county/Needles
+      directories.
+- [ ] Monthly GSC review; retune titles/descriptions against real query impressions.
+
+## Acceptance criteria
+
+- [ ] All three pages present in `sitemap.xml` and indexed in Search Console.
+- [ ] `water.html`/`radar.html` each have canonical, OG tags, h1, and valid JSON-LD
+      (Rich Results test passes).
+- [ ] "Havasu Landing" appears in on-page copy and schema.
+- [ ] `www.havasulakeweather.com/*` 301s to apex; `/water` and `/radar` resolve 200.
+- [ ] Unknown paths return a 404 page with HTTP 404.
+- [ ] Measurable: site moves off page 5 for "Havasu Lake weather" (track in GSC; expect
+      movement over weeks, not days).
+
+## Notes
+
+- Full audit report in chat (2026-08-23): top findings, keyword table with intent +
+  competition, and sources (NWS zone, USGS 09427500, USBR schedules, competitor pages).
+- Authority (backlinks) is the #1 lever; on-page fixes are necessary but not sufficient.
+- Keyword targets: "havasu lake weather", "havasu landing weather", "havasu lake vs lake
+  havasu city", "lake havasu water temperature", "parker dam water release",
+  CA-qualified radar/level long-tails.

--- a/web/index.html
+++ b/web/index.html
@@ -47,7 +47,7 @@
     { "@type": "WebSite", "@id": "https://havasulakeweather.com/#website", "url": "https://havasulakeweather.com/", "name": "Havasu Lake Weather", "alternateName": "Havasu Lake, CA Weather", "description": "Live outdoor weather for Havasu Lake, California — temperature, wind, rain, UV and 24-hour history from a personal Ambient Weather station.", "inLanguage": "en-US", "publisher": { "@id": "https://havasulakeweather.com/#operator" } },
     { "@type": "WebPage", "@id": "https://havasulakeweather.com/#webpage", "url": "https://havasulakeweather.com/", "name": "Havasu Lake, CA Weather — Live Conditions", "isPartOf": { "@id": "https://havasulakeweather.com/#website" }, "primaryImageOfPage": "https://havasulakeweather.com/assets/og-image.png", "about": { "@id": "https://havasulakeweather.com/#place" }, "description": "Real-time temperature, wind, rain, UV, humidity and pressure for Havasu Lake, California, from a personal Ambient Weather WS-2902D station." },
     { "@type": "Person", "@id": "https://havasulakeweather.com/#operator", "name": "Chad Woskoski", "description": "Local resident who operates and maintains the Havasu Lake, CA community weather station." },
-    { "@type": "Place", "@id": "https://havasulakeweather.com/#place", "name": "Havasu Lake, California", "alternateName": "Havasu Lake, CA", "description": "Community on the California shore of Lake Havasu in San Bernardino County — distinct from Lake Havasu City, Arizona.", "geo": { "@type": "GeoCoordinates", "latitude": 34.4822, "longitude": -114.4138 }, "address": { "@type": "PostalAddress", "addressLocality": "Havasu Lake", "addressRegion": "CA", "postalCode": "92363", "addressCountry": "US" }, "containedInPlace": { "@type": "AdministrativeArea", "name": "San Bernardino County, California" } }
+    { "@type": "Place", "@id": "https://havasulakeweather.com/#place", "name": "Havasu Lake, California", "alternateName": ["Havasu Lake, CA", "Havasu Landing", "Havasu Landing, CA"], "description": "Community on the California (Colorado River) shore of Lake Havasu in San Bernardino County — home to the Havasu Landing Resort & Casino — distinct from Lake Havasu City, Arizona.", "geo": { "@type": "GeoCoordinates", "latitude": 34.4822, "longitude": -114.4138 }, "address": { "@type": "PostalAddress", "addressLocality": "Havasu Lake", "addressRegion": "CA", "postalCode": "92363", "addressCountry": "US" }, "containedInPlace": { "@type": "AdministrativeArea", "name": "San Bernardino County, California" }, "sameAs": ["https://en.wikipedia.org/wiki/Havasu_Lake,_California", "https://www.wikidata.org/wiki/Q14682145"] }
   ]
 }
 </script>
@@ -102,6 +102,8 @@
   .page{position:relative;z-index:2;max-width:720px;margin:0 auto;padding:max(26px,env(safe-area-inset-top)) 16px calc(40px + env(safe-area-inset-bottom));display:flex;flex-direction:column;gap:16px;min-height:100vh;}
   .glass{background:var(--glass-bg);border:1px solid var(--glass-brd);border-radius:var(--radius);box-shadow:var(--glass-shadow),inset 0 1px 0 var(--glass-hi);backdrop-filter:var(--blur);-webkit-backdrop-filter:var(--blur);}
   .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;}
+  .ftnav{margin-top:8px;font-weight:700;}
+  .ftnav a{color:var(--ink-soft);white-space:nowrap;}
   h2.kicker{margin:0;}
   .about{padding:20px;}
   .about h2{margin:0 0 8px;font-size:1.05rem;font-weight:800;color:var(--ink);}
@@ -576,7 +578,7 @@
     <!-- ABOUT (static, indexable) -->
     <section class="glass about" aria-labelledby="about-h">
       <h2 id="about-h">About this weather station</h2>
-      <p><b>Havasu Lake Weather</b> shows live outdoor conditions for <b>Havasu Lake, California</b> — the small community in San Bernardino County on the California (west) shore of Lake Havasu, across the water from Lake Havasu City, Arizona. To be clear: this is <b>Havasu Lake, CA (ZIP 92363)</b>, not Lake Havasu City, AZ.</p>
+      <p><b>Havasu Lake Weather</b> shows live outdoor conditions for <b>Havasu Lake, California</b> — the small community in San Bernardino County, home to <b>Havasu Landing</b>, on the California (west) shore of Lake Havasu along the <b>Colorado River</b>, across the water from Lake Havasu City, Arizona. To be clear: this is <b>Havasu Lake, CA (ZIP 92363)</b>, not Lake Havasu City, AZ.</p>
       <p>Readings come from a personal <b>Ambient Weather WS-2902D</b> station in Havasu Lake and refresh about once a minute. You'll find the current <b>temperature</b> and feels-like, <b>wind</b> speed, gusts and direction, whether it's <b>raining right now</b>, plus humidity, dew point, UV index, barometric pressure and today's rainfall — with 24-hour and 7-day history charts.</p>
       <p>A local resident keeps the station running for neighbors and lake-goers planning boating, fishing and desert-summer days on the water. It's for community reference only and is <b>not an official National Weather Service observation</b>.</p>
     </section>
@@ -606,6 +608,7 @@
     <footer class="footer">
       <div>Personal WS-2902D weather station &mdash; not an official observation.</div>
       <div>Havasu Lake, CA &middot; Ambient Weather &middot; Outdoor readings only</div>
+      <nav class="ftnav" aria-label="Site"><a href="/">Live conditions</a> &middot; <a href="/radar.html">Radar</a> &middot; <a href="/water.html">Lake Havasu water level</a></nav>
     </footer>
   </main>
 

--- a/web/radar.html
+++ b/web/radar.html
@@ -10,7 +10,33 @@
 <meta name="apple-mobile-web-app-capable" content="yes" />
 <meta name="apple-mobile-web-app-title" content="Havasu Wx" />
 <meta name="description" content="Live weather radar for Havasu Lake, CA and the Colorado River — animated precipitation from RainViewer (past 2 hours + short-term nowcast)." />
-<title>Radar — Havasu Lake, CA</title>
+<title>Weather Radar — Havasu Lake, CA &amp; the Colorado River (Live Precipitation)</title>
+<link rel="canonical" href="https://havasulakeweather.com/radar.html" />
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="Havasu Lake Weather" />
+<meta property="og:title" content="Weather Radar — Havasu Lake, CA (Live Precipitation)" />
+<meta property="og:description" content="Live animated weather radar for Havasu Lake, California and the Colorado River — past 2 hours of precipitation plus a short-term nowcast, from RainViewer." />
+<meta property="og:url" content="https://havasulakeweather.com/radar.html" />
+<meta property="og:image" content="https://havasulakeweather.com/assets/og-image.png" />
+<meta property="og:image:type" content="image/png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="Weather Radar — Havasu Lake, CA (Live Precipitation)" />
+<meta name="twitter:description" content="Live animated precipitation radar for Havasu Lake, CA and the Colorado River." />
+<meta name="twitter:image" content="https://havasulakeweather.com/assets/og-image.png" />
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    { "@type": "WebPage", "@id": "https://havasulakeweather.com/radar.html#webpage", "url": "https://havasulakeweather.com/radar.html", "name": "Weather Radar — Havasu Lake, CA (Live Precipitation)", "isPartOf": { "@id": "https://havasulakeweather.com/#website" }, "about": { "@id": "https://havasulakeweather.com/#place" }, "description": "Live animated weather radar centered on Havasu Lake, California and the Colorado River, showing the past two hours of precipitation and a short-term nowcast." },
+    { "@type": "BreadcrumbList", "@id": "https://havasulakeweather.com/radar.html#breadcrumb", "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Havasu Lake, CA Weather", "item": "https://havasulakeweather.com/" },
+      { "@type": "ListItem", "position": 2, "name": "Weather Radar" }
+    ] }
+  ]
+}
+</script>
 <!-- Google Analytics (GA4) — loads only on the live domain (page_view tracks /radar visits). -->
 <script>
   (function () {
@@ -55,6 +81,9 @@
   .rlegend .sw{width:16px;height:9px;border-radius:2px;display:inline-block;}
   .foot{text-align:center;font-size:.72rem;color:var(--ink-faint);line-height:1.5;}
   .foot a{color:var(--ink-soft);}
+  .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;}
+  .ftnav{margin-top:8px;font-weight:700;}
+  .ftnav a{color:var(--ink-soft);white-space:nowrap;}
 </style>
 </head>
 <body>
@@ -64,6 +93,7 @@
   </header>
 
   <main class="rpage">
+    <h1 class="sr-only">Havasu Lake, CA Weather Radar — Live Precipitation over the Colorado River</h1>
     <div id="map" aria-label="Live precipitation radar centered on Havasu Lake"></div>
     <div class="rctrl">
       <button class="rplay" id="rPlay" type="button" aria-label="Play/pause radar">&#9208;</button>
@@ -78,6 +108,7 @@
       Radar: <a href="https://www.rainviewer.com/" target="_blank" rel="noopener">RainViewer</a> &middot;
       map &copy; OpenStreetMap / CARTO &middot; community reference, not an official product.
       <a href="/water.html">Lake &amp; river &rarr;</a>
+      <nav class="ftnav" aria-label="Site"><a href="/">Live conditions</a> &middot; <a href="/water.html">Lake Havasu water level</a> &middot; <a href="/radar.html">Radar</a></nav>
     </div>
   </main>
 

--- a/web/sitemap.xml
+++ b/web/sitemap.xml
@@ -2,8 +2,20 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://havasulakeweather.com/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-24</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://havasulakeweather.com/water.html</loc>
+    <lastmod>2026-08-24</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://havasulakeweather.com/radar.html</loc>
+    <lastmod>2026-08-24</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.7</priority>
   </url>
 </urlset>

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,5 +1,5 @@
 /* Havasu Lake Weather — service worker (installability + offline shell) */
-const CACHE = "havasu-wx-v31";
+const CACHE = "havasu-wx-v32";
 const SHELL = [
   "/", "/index.html", "/water.html", "/radar.html", "/manifest.json", "/sw-register.js",
   "/assets/icon-192.png", "/assets/icon-512.png", "/assets/icon-180.png",

--- a/web/water.html
+++ b/web/water.html
@@ -10,7 +10,33 @@
 <meta name="apple-mobile-web-app-capable" content="yes" />
 <meta name="apple-mobile-web-app-title" content="Havasu Wx" />
 <meta name="description" content="Lake Havasu water conditions for Havasu Lake, CA — live lake level, Davis & Parker Dam releases (inflow/outflow), and water temperature." />
-<title>Lake &amp; River — Havasu Lake, CA</title>
+<title>Lake Havasu Water Level, Dam Releases &amp; Water Temperature — Live (Havasu Lake, CA)</title>
+<link rel="canonical" href="https://havasulakeweather.com/water.html" />
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="Havasu Lake Weather" />
+<meta property="og:title" content="Lake Havasu Water Level, Dam Releases &amp; Water Temperature — Havasu Lake, CA" />
+<meta property="og:description" content="Live Lake Havasu level, Davis &amp; Parker Dam releases, and water temperature for Havasu Lake, California — plus the full Colorado River reservoir cascade from Lake Powell to Lake Havasu." />
+<meta property="og:url" content="https://havasulakeweather.com/water.html" />
+<meta property="og:image" content="https://havasulakeweather.com/assets/og-image.png" />
+<meta property="og:image:type" content="image/png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="Lake Havasu Water Level, Dam Releases &amp; Water Temperature" />
+<meta name="twitter:description" content="Live Lake Havasu level, Parker &amp; Davis Dam releases, and water temperature for Havasu Lake, CA." />
+<meta name="twitter:image" content="https://havasulakeweather.com/assets/og-image.png" />
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    { "@type": "WebPage", "@id": "https://havasulakeweather.com/water.html#webpage", "url": "https://havasulakeweather.com/water.html", "name": "Lake Havasu Water Level, Dam Releases & Water Temperature", "isPartOf": { "@id": "https://havasulakeweather.com/#website" }, "about": { "@id": "https://havasulakeweather.com/#place" }, "description": "Live Lake Havasu level, Davis and Parker Dam releases, and water temperature for Havasu Lake, California, with the Colorado River reservoir cascade from Lake Powell down to Lake Havasu." },
+    { "@type": "BreadcrumbList", "@id": "https://havasulakeweather.com/water.html#breadcrumb", "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Havasu Lake, CA Weather", "item": "https://havasulakeweather.com/" },
+      { "@type": "ListItem", "position": 2, "name": "Lake Havasu Water Level & Dam Releases" }
+    ] }
+  ]
+}
+</script>
 <!-- Google Analytics (GA4) — loads only on the live domain (page_view tracks /water visits). -->
 <script>
   (function () {
@@ -167,6 +193,9 @@
   .wgoes-note{margin-top:12px;font-size:.77rem;font-weight:600;color:var(--ink-faint);line-height:1.42;}
   .wgoes-note b{color:var(--ink-soft);}
   .casc-note{font-size:.72rem;font-weight:600;color:var(--ink-faint);text-align:center;margin-top:2px;}
+  .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;}
+  .ftnav{margin-top:8px;font-weight:700;}
+  .ftnav a{color:var(--ink-soft);white-space:nowrap;}
 </style>
 </head>
 <body>
@@ -176,6 +205,7 @@
   </header>
 
   <main class="wpage">
+    <h1 class="sr-only">Lake Havasu Water Level, Dam Releases &amp; Water Temperature — Havasu Lake, CA</h1>
     <div id="warnings"></div>
     <div class="casc-intro">The Colorado, top to bottom — every drop that reaches Lake Havasu passes through these first.</div>
     <div id="cascade" class="cascade" aria-label="Colorado River — Lake Powell down to Lake Havasu"></div>
@@ -224,6 +254,7 @@
     <div class="foot">
       Lake level: USGS · Dam releases &amp; water temp: USBR RISE · updates ~hourly.<br>
       Community reference only &mdash; not an official forecast. <a href="/">&larr; back to conditions</a>
+      <nav class="ftnav" aria-label="Site"><a href="/">Live conditions</a> &middot; <a href="/radar.html">Radar</a> &middot; <a href="/water.html">Lake Havasu water level</a></nav>
     </div>
   </main>
 


### PR DESCRIPTION
Phase 1 of #56 (SEO) — web-only quick wins from the 2026-08-23 audit. Rides normal CI/CD.

## Changes
- **sitemap.xml** — added `/water.html` + `/radar.html`; `lastmod` 2026-08-24 (all three pages changed today).
- **water.html / radar.html** — were near-invisible to search: added `<link rel=canonical>`, OG + Twitter tags, an sr-only `<h1>`, and WebPage + BreadcrumbList JSON-LD. `/water` `<title>` → "Lake Havasu Water Level, Dam Releases & Water Temperature — Live (Havasu Lake, CA)".
- **index.html** — "Havasu Landing" + "Colorado River" woven into About copy and `Place.alternateName`; added `sameAs` (Wikipedia + Wikidata **Q14682145**, which carries GNIS **1660731**).
- **All 3 pages** — persistent keyword footer nav (Live conditions · Radar · Lake Havasu water level), always visible, no JS gate.
- SW cache → **v32**.

## Verified (Playwright, static preview)
All three JSON-LD blocks parse; each page has canonical + OG + Twitter + `<h1>` + footer nav; 0 unexpected console errors (only offline `/api/*` 404s from the backend-less static server).

## Not in this PR
- **Phase 2 (infra):** `www`→apex 301, extensionless `/water` rewrite, 403→404 — needs `site-template.yaml` + separate approval.
- **No-code:** verify GSC + Bing, submit sitemap (Chad).
- Deploy-workflow `lastmod` auto-stamp — deferred.

Merging deploys the site via the pipeline — your call.