### PR TITLE
HLW-028: SEO Phase 2 — CloudFront www→apex, clean URLs, 404 page

### DIFF
--- a/docs/issues/HLW-028-seo-improvements.md
+++ b/docs/issues/HLW-028-seo-improvements.md
@@ -1,6 +1,6 @@
 # HLW-028: SEO — get havasulakeweather.com ranking for local weather queries
 
-- **Status:** in-progress — Phase 1 built + previewed (0 console errors), in PR
+- **Status:** in-progress — Phase 1 shipped 2026-08-24; Phase 2 built, pending manual site-stack deploy (this PR)
 - **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/56
 - **Branch:** `feat/HLW-028-seo` (Phase 1; later phases may use their own branches)
 - **PR:** <url>
@@ -45,11 +45,12 @@ duplicate `www` host, and `/water` (extensionless) returning a raw S3 403.
 
 ### Phase 2 — infra (`site-template.yaml`, separate approval)
 
-- [ ] CloudFront Function on default behavior: 301 `www` → apex; rewrite extensionless
-      paths (`/water` → `/water.html`); standardize canonicals/sitemap/internal links on
-      clean URLs.
-- [ ] `CustomErrorResponses`: 403 → `/404.html` with response code 404; add a simple
-      404 page.
+- [x] CloudFront Function (viewer-request, default behavior only): 301 `www` → apex;
+      rewrite extensionless paths (`/water` → `/water.html`). Canonicals/sitemap/nav kept
+      on `.html` for now (they resolve and are canonical) — clean-URL standardization deferred.
+- [x] `CustomErrorResponses`: 403 → `/404.html` (response code 404) + a branded
+      `web/404.html`. **Deploy = a manual `cloudformation deploy` of `havasu-weather-site`
+      (us-east-1); the auto-pipeline does not deploy this stack.**
 
 ### Phase 3 — content (one PR per page/section)
 

--- a/site-template.yaml
+++ b/site-template.yaml
@@ -72,6 +72,41 @@ Resources:
           QueryStringsConfig:
             QueryStringBehavior: all
 
+  # Viewer-request function on the default (site) behavior only — NOT on /api/*
+  # (that behavior has no association). Redirects www -> apex and rewrites
+  # extensionless clean URLs (/water -> /water.html) so they resolve instead of 403.
+  SiteFunction:
+    Type: AWS::CloudFront::Function
+    Properties:
+      Name: !Sub "havasu-site-rewrite-${AWS::AccountId}"
+      AutoPublish: true
+      FunctionConfig:
+        Comment: "www->apex 301 + extensionless .html rewrite"
+        Runtime: cloudfront-js-2.0
+      FunctionCode: !Sub |
+        function handler(event) {
+          var request = event.request;
+          var host = request.headers.host ? request.headers.host.value : '';
+          if (host === 'www.${DomainName}') {
+            var qs = request.querystring;
+            var q = '';
+            for (var k in qs) {
+              q += (q ? '&' : '?') + k + (qs[k].value !== '' ? '=' + qs[k].value : '');
+            }
+            return {
+              statusCode: 301,
+              statusDescription: 'Moved Permanently',
+              headers: { 'location': { value: 'https://${DomainName}' + request.uri + q } }
+            };
+          }
+          var uri = request.uri;
+          var seg = uri.slice(uri.lastIndexOf('/'));
+          if (uri !== '/' && uri.charAt(uri.length - 1) !== '/' && seg.indexOf('.') === -1) {
+            request.uri = uri + '.html';
+          }
+          return request;
+        }
+
   Distribution:
     Type: AWS::CloudFront::Distribution
     Properties:
@@ -106,6 +141,9 @@ Resources:
           Compress: true
           AllowedMethods: [GET, HEAD]
           CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6 # Managed-CachingOptimized
+          FunctionAssociations:
+            - EventType: viewer-request
+              FunctionARN: !GetAtt SiteFunction.FunctionMetadata.FunctionARN
         CacheBehaviors:
           - PathPattern: /api/*
             TargetOriginId: api
@@ -114,6 +152,14 @@ Resources:
             AllowedMethods: [GET, HEAD, OPTIONS]
             CachePolicyId: !Ref ApiCachePolicy
             OriginRequestPolicyId: b689b0a8-53d0-40ab-baf2-68738e2966ac # AllViewerExceptHostHeader
+        # Missing static objects come back from S3+OAC as 403 (not 404) — serve the
+        # branded 404 page with a real 404 status. Distribution-wide; the read API
+        # returns 200 for the endpoints the app calls, so this only affects unknown paths.
+        CustomErrorResponses:
+          - ErrorCode: 403
+            ResponseCode: 404
+            ResponsePagePath: /404.html
+            ErrorCachingMinTTL: 60
 
   BucketPolicy:
     Type: AWS::S3::BucketPolicy

--- a/web/404.html
+++ b/web/404.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+<meta name="theme-color" content="#0e4a5e" />
+<meta name="robots" content="noindex" />
+<link rel="icon" type="image/png" href="/assets/icon-192.png" />
+<link rel="apple-touch-icon" href="/assets/icon-180.png" />
+<title>Page not found — Havasu Lake Weather</title>
+<style>
+  :root{--bg:#062a34;--ink:#eaf6f8;--ink-soft:#a9c7ce;--teal:#7fe6e2;--brd:rgba(255,255,255,.14);}
+  *{box-sizing:border-box;}
+  body{margin:0;min-height:100dvh;display:flex;align-items:center;justify-content:center;
+    background:radial-gradient(120% 120% at 50% 0%,#0e4a5e,#062a34);color:var(--ink);
+    font:500 16px/1.5 ui-rounded,'SF Pro Rounded','Segoe UI',system-ui,-apple-system,sans-serif;
+    padding:24px;text-align:center;-webkit-font-smoothing:antialiased;}
+  .card{max-width:440px;}
+  .big{font-size:4rem;font-weight:800;color:var(--teal);line-height:1;margin:0;}
+  h1{font-size:1.3rem;font-weight:800;margin:10px 0 6px;}
+  p{color:var(--ink-soft);margin:0 0 20px;}
+  nav{display:flex;flex-wrap:wrap;gap:10px;justify-content:center;}
+  a{display:inline-block;padding:10px 16px;border-radius:999px;border:1px solid var(--brd);
+    color:var(--ink);text-decoration:none;font-weight:700;background:rgba(255,255,255,.05);}
+  a.primary{background:var(--teal);color:#04222a;border-color:transparent;}
+</style>
+</head>
+<body>
+  <main class="card">
+    <p class="big">404</p>
+    <h1>That page drifted downstream</h1>
+    <p>We couldn&rsquo;t find that page for <b>Havasu Lake, CA</b>. Try one of these:</p>
+    <nav>
+      <a class="primary" href="/">Live conditions</a>
+      <a href="/water.html">Lake &amp; river</a>
+      <a href="/radar.html">Radar</a>
+    </nav>
+  </main>
+</body>
+</html>

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,5 +1,5 @@
 /* Havasu Lake Weather — service worker (installability + offline shell) */
-const CACHE = "havasu-wx-v34";  // bump on EVERY web/ change (cache correctness; CI-enforced)
+const CACHE = "havasu-wx-v35";  // bump on EVERY web/ change (cache correctness; CI-enforced)
 const RELEASE = "r1";           // bump ONLY for user-facing changes — drives the "update available" toast
 const SHELL = [
   "/", "/index.html", "/water.html", "/radar.html", "/manifest.json", "/sw-register.js",


### PR DESCRIPTION
Phase 2 of #56 — the infra fixes from the audit. **Heads-up: this touches `site-template.yaml`, which the auto-pipeline does NOT deploy.**

## Changes
- **CloudFront Function** (`SiteFunction`, viewer-request, on the **default behavior only** — never `/api/*`):
  - 301 `www.havasulakeweather.com` → apex (fixes the duplicate host).
  - Rewrites extensionless clean URLs (`/water` → `/water.html`) so they resolve 200 instead of a raw S3 403.
- **`CustomErrorResponses`**: 403 (what S3+OAC returns for a missing object) → **`/404.html` at HTTP 404**.
- **`web/404.html`**: branded, `noindex`, links back to conditions / lake & river / radar.
- SW cache → **v33**.

## ⚠️ Deploy is two steps (both gated)
1. **Merge this PR** → the pipeline's site job syncs `web/404.html` (and the v33 SW) to S3. CloudFront config is unchanged so far. *(Do this first so `/404.html` exists before the error response points at it.)*
2. **Manually deploy the site stack** (not automated):
   ```
   aws cloudformation deploy --template-file site-template.yaml \
     --stack-name havasu-weather-site --capabilities CAPABILITY_IAM \
     --region us-east-1 --profile havasu
   ```
   This creates the CloudFront Function + error responses. Distribution updates take ~5–15 min to propagate.

## Notes / caveats
- Canonicals, sitemap, and nav stay on `.html` for now (they resolve and are canonical) — clean-URL standardization is deferred so we don't juggle `.html`↔clean redirects.
- `CustomErrorResponses` are distribution-wide, so a 403 from `/api/*` would also serve `/404.html`. The read API returns 200 for the endpoints the app calls, so impact is limited to unknown paths.

## Validated
cfn-lint clean (`sam validate --lint`); the CloudFront Function JS parses (`node --check`).