### PR TITLE
HLW-042: only toast for user-facing releases (SW RELEASE marker)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,8 @@ aws cloudfront create-invalidation --distribution-id E1FK70K9FGVU2M --paths "/*"
 
 - **Node 24** (`nodejs24.x`), ESM modules; AWS SDK v3 ships in the runtime.
 - **PWA:** bump `web/sw.js` `CACHE` (`havasu-wx-vN`) on any `web/` change so installed
-  users pick up the update.
+  users pick up the update. Bump **`RELEASE`** (`web/sw.js`) **only** for user-facing changes —
+  that alone triggers the "New version available" toast; cache-only changes (SEO, backend,
+  infra, docs) activate silently with no prompt (HLW-042).
 - **Outdoor data only** — never store indoor readings.
 - **Secrets** are NoEcho SAM params, passed via `--parameter-overrides`, never committed.

--- a/docs/issues/HLW-042-sw-release-flag.md
+++ b/docs/issues/HLW-042-sw-release-flag.md
@@ -1,0 +1,42 @@
+# HLW-042: Flag releases so the update toast only shows for user-facing changes
+
+- **Status:** in-progress (built + validated; in PR)
+- **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/74
+- **Branch:** `feat/HLW-042-sw-release-flag`
+- **Created:** 2026-08-24
+
+## Problem
+
+Every `web/` change requires bumping the service-worker `CACHE` version (CI-enforced, for
+cache correctness). But `sw-register.js` shows the **"New version available"** toast on *any*
+new waiting worker — so cache-only changes with nothing user-facing (SEO meta, the 404 page,
+backend-ish tweaks) still nag every installed user to refresh. E.g. the HLW-028 SEO deploys
+would each have prompted users despite no visible change.
+
+## Fix — decouple "cache version" from "notify the user"
+
+- **`web/sw.js`**: keep `CACHE` (bump every `web/` change). Add a separate **`RELEASE`** marker
+  bumped **only for user-facing changes**, and a message handler so the page can read a worker's
+  `RELEASE` (MessageChannel `GET_RELEASE` → `{ release }`).
+- **`web/sw-register.js`**: when a worker is waiting, compare its `RELEASE` to the running
+  worker's:
+  - **different** → show the toast (as before; tap → activate → reload).
+  - **same** (or unknown) → activate the new worker **silently** in the background; no toast,
+    no forced reload. The `controllerchange` reload is now gated on a user tap
+    (`userInitiatedReload`), so silent activations don't reload the page.
+- **`CLAUDE.md`**: document the two-marker convention.
+
+## Behavior
+
+- Default is **silent** — don't touch `RELEASE` → no toast. Opt in to the prompt by bumping it.
+- First install and the one-time upgrade *to* this release-aware worker are silent (the old
+  worker can't report a `RELEASE`, so the comparison is "unknown" → silent).
+- `CACHE` → **v34** (v33 is reserved by the open Phase 2 PR #73; may need a one-line merge
+  resolve on `web/sw.js` depending on merge order — keep the highest version).
+
+## Acceptance
+
+- [x] `node --check` passes on both SW files.
+- [ ] CI green on the PR.
+- [ ] After deploy: a cache-only bump (RELEASE unchanged) does **not** show the toast; a
+      RELEASE bump does. (Verify on the next couple of deploys.)

--- a/web/sw-register.js
+++ b/web/sw-register.js
@@ -18,11 +18,29 @@
   }
 
   var refreshing = false;
+  var userInitiatedReload = false; // only reload the page for a user-tapped update, not silent ones
   navigator.serviceWorker.addEventListener("controllerchange", function () {
-    if (refreshing) return;      // the waiting worker took control — reload once to pick it up
+    if (refreshing || !userInitiatedReload) return; // silent background activation → don't reload
     refreshing = true;
     window.location.reload();
   });
+
+  // Ask a worker for its RELEASE marker (MessageChannel round-trip). Resolves null when the
+  // worker is absent or too old to answer (the pre-HLW-042 worker) — treated as "unknown".
+  function getRelease(worker) {
+    return new Promise(function (resolve) {
+      if (!worker) return resolve(null);
+      var ch = new MessageChannel();
+      var done = false;
+      ch.port1.onmessage = function (e) {
+        if (done) return; done = true;
+        resolve((e.data && e.data.release) || null);
+      };
+      try { worker.postMessage({ type: "GET_RELEASE" }, [ch.port2]); }
+      catch (err) { return resolve(null); }
+      setTimeout(function () { if (!done) { done = true; resolve(null); } }, 1500);
+    });
+  }
 
   function showToast(onRefresh) {
     if (document.getElementById("swUpdateToast")) return; // already showing
@@ -51,21 +69,36 @@
     requestAnimationFrame(function () { wrap.style.opacity = "1"; wrap.style.transform = "translateX(-50%) translateY(0)"; });
   }
 
-  function promptUpdate(reg) {
-    if (reg.waiting) showToast(function () { reg.waiting.postMessage("SKIP_WAITING"); });
+  // Show the toast only when the RELEASE marker changed (a real user-facing update). For a
+  // cache-only change (same RELEASE — SEO, backend, infra) activate silently in the background,
+  // so those never nag the user with "New version available".
+  function handleWaiting(reg) {
+    if (!reg.waiting) return;
+    Promise.all([getRelease(reg.waiting), getRelease(navigator.serviceWorker.controller)])
+      .then(function (rels) {
+        var next = rels[0], current = rels[1];
+        if (next && current && next !== current) {
+          showToast(function () {
+            userInitiatedReload = true;
+            reg.waiting.postMessage("SKIP_WAITING");
+          });
+        } else {
+          reg.waiting.postMessage("SKIP_WAITING"); // silent: same release, or unknown/first upgrade
+        }
+      });
   }
 
   window.addEventListener("load", function () {
     navigator.serviceWorker.register("/sw.js").then(function (reg) {
       // An update may already be waiting (installed on a prior visit / another tab).
-      if (reg.waiting && navigator.serviceWorker.controller) promptUpdate(reg);
+      if (reg.waiting && navigator.serviceWorker.controller) handleWaiting(reg);
       // Or one starts installing now — prompt once it finishes (and only if this isn't the
       // first-ever install, i.e. a controller already exists).
       reg.addEventListener("updatefound", function () {
         var nw = reg.installing;
         if (!nw) return;
         nw.addEventListener("statechange", function () {
-          if (nw.state === "installed" && navigator.serviceWorker.controller) promptUpdate(reg);
+          if (nw.state === "installed" && navigator.serviceWorker.controller) handleWaiting(reg);
         });
       });
     }).catch(function () {});

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,5 +1,6 @@
 /* Havasu Lake Weather — service worker (installability + offline shell) */
-const CACHE = "havasu-wx-v32";
+const CACHE = "havasu-wx-v34";  // bump on EVERY web/ change (cache correctness; CI-enforced)
+const RELEASE = "r1";           // bump ONLY for user-facing changes — drives the "update available" toast
 const SHELL = [
   "/", "/index.html", "/water.html", "/radar.html", "/manifest.json", "/sw-register.js",
   "/assets/icon-192.png", "/assets/icon-512.png", "/assets/icon-180.png",
@@ -14,7 +15,12 @@ self.addEventListener("install", (e) => {
 
 // The page posts SKIP_WAITING when the user taps Refresh → activate this worker now.
 self.addEventListener("message", (e) => {
-  if (e.data === "SKIP_WAITING" || (e.data && e.data.type === "SKIP_WAITING")) self.skipWaiting();
+  const data = e.data;
+  if (data === "SKIP_WAITING" || (data && data.type === "SKIP_WAITING")) self.skipWaiting();
+  // The page asks each worker for its RELEASE to decide whether to prompt (see sw-register.js).
+  if (data && data.type === "GET_RELEASE" && e.ports && e.ports[0]) {
+    e.ports[0].postMessage({ release: RELEASE });
+  }
 });
 
 self.addEventListener("activate", (e) => {


### PR DESCRIPTION
Closes #74. Ticket: `docs/issues/HLW-042-sw-release-flag.md`.

**Problem:** every `web/` change bumps the SW `CACHE` (CI-enforced), and any new waiting worker made `sw-register.js` show the **"New version available"** toast — so cache-only changes (SEO meta, the 404 page, backend tweaks) nagged every user with nothing to see. The recent SEO deploys would each have prompted needlessly.

**Fix — decouple cache version from user notification:**
- `web/sw.js`: keep `CACHE` (bump every `web/` change). Add a `RELEASE` marker, bumped **only** for user-facing changes, plus a `GET_RELEASE` message handler.
- `web/sw-register.js`: when a worker is waiting, compare its `RELEASE` to the running one — **toast only if they differ**; otherwise **activate silently** (no toast, no forced reload). The `controllerchange` reload is now gated on a user tap.
- `CLAUDE.md`: documents the convention (bump `CACHE` every change; bump `RELEASE` for features only).

**Behavior:** default is silent — you opt *in* to the prompt by bumping `RELEASE`. First install and the one-time upgrade to this worker are silent (the old worker can't report a `RELEASE`).

**Note:** `CACHE` → **v34** (v33 is claimed by the open Phase 2 PR #73). If #73 lands first, expect a one-line `web/sw.js` conflict — resolve by keeping the highest version.

Validated: `node --check` passes on both SW files.