### PR TITLE
fix(seo): shorten water + radar page titles (Bing 'title too long')

### DIFF
--- a/web/radar.html
+++ b/web/radar.html
@@ -10,7 +10,7 @@
 <meta name="apple-mobile-web-app-capable" content="yes" />
 <meta name="apple-mobile-web-app-title" content="Havasu Wx" />
 <meta name="description" content="Live weather radar for Havasu Lake, CA and the Colorado River — animated precipitation from RainViewer (past 2 hours + short-term nowcast)." />
-<title>Weather Radar — Havasu Lake, CA &amp; the Colorado River (Live Precipitation)</title>
+<title>Weather Radar — Havasu Lake, CA (Live Precipitation)</title>
 <link rel="canonical" href="https://havasulakeweather.com/radar.html" />
 <meta property="og:type" content="website" />
 <meta property="og:site_name" content="Havasu Lake Weather" />

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,5 +1,5 @@
 /* Havasu Lake Weather — service worker (installability + offline shell) */
-const CACHE = "havasu-wx-v35";  // bump on EVERY web/ change (cache correctness; CI-enforced)
+const CACHE = "havasu-wx-v36";  // bump on EVERY web/ change (cache correctness; CI-enforced)
 const RELEASE = "r1";           // bump ONLY for user-facing changes — drives the "update available" toast
 const SHELL = [
   "/", "/index.html", "/water.html", "/radar.html", "/manifest.json", "/sw-register.js",

--- a/web/water.html
+++ b/web/water.html
@@ -10,7 +10,7 @@
 <meta name="apple-mobile-web-app-capable" content="yes" />
 <meta name="apple-mobile-web-app-title" content="Havasu Wx" />
 <meta name="description" content="Lake Havasu water conditions for Havasu Lake, CA — live lake level, Davis & Parker Dam releases (inflow/outflow), and water temperature." />
-<title>Lake Havasu Water Level, Dam Releases &amp; Water Temperature — Live (Havasu Lake, CA)</title>
+<title>Lake Havasu Water Level &amp; Dam Releases — Havasu Lake, CA</title>
 <link rel="canonical" href="https://havasulakeweather.com/water.html" />
 <meta property="og:type" content="website" />
 <meta property="og:site_name" content="Havasu Lake Weather" />


### PR DESCRIPTION
Bing Webmaster's SEO analysis flagged the `/water` `<title>` (~82 chars) as **too long** — it truncates in search results. `/radar` (~73) was borderline. Trimmed both under ~60, keeping the top keywords:

- **water:** `Lake Havasu Water Level & Dam Releases — Havasu Lake, CA` (56)
- **radar:** `Weather Radar — Havasu Lake, CA (Live Precipitation)` (52)

Water temperature / Colorado River still live in each page's `<meta description>`, `og:title`, and `<h1>`.

`CACHE` → **v36**; **`RELEASE` unchanged** — so this deploys **silently** (no "new version available" toast), which is exactly what HLW-042 is for. Part of #56.