### PR TITLE
HLW-043: IndexNow ping on each site deploy (instant Bing/Yandex recrawl)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,6 +66,23 @@ jobs:
         run: aws s3 sync web/ s3://havasu-weather-site-648581682379/ --delete --region us-east-1
       - name: Invalidate CloudFront
         run: aws cloudfront create-invalidation --distribution-id E1FK70K9FGVU2M --paths "/*"
+      - name: Ping IndexNow (Bing / Yandex instant recrawl — Google ignores it)
+        run: |
+          KEY="23b65e54-7ebe-45ca-aff4-d9fbe16c00e8"
+          # Submit the sitemap's canonical URLs (parsed from the just-deployed file, not the
+          # possibly-cached live copy). Best-effort — never fail the deploy on a bad ping.
+          urls=$(grep -oE '<loc>[^<]*</loc>' web/sitemap.xml | sed 's/<[^>]*>//g')
+          if [ -z "$urls" ]; then echo "::warning::no sitemap URLs found; skipping IndexNow"; exit 0; fi
+          list=$(printf '%s\n' "$urls" | sed 's/.*/"&"/' | paste -sd, -)
+          body=$(printf '{"host":"havasulakeweather.com","key":"%s","keyLocation":"https://havasulakeweather.com/%s.txt","urlList":[%s]}' "$KEY" "$KEY" "$list")
+          echo "IndexNow urlList: $list"
+          code=$(curl -sS -o /tmp/indexnow.out -w '%{http_code}' -X POST "https://api.indexnow.org/indexnow" \
+                   -H "Content-Type: application/json; charset=utf-8" -d "$body" || echo "000")
+          echo "IndexNow HTTP $code — $(cat /tmp/indexnow.out 2>/dev/null)"
+          case "$code" in
+            200|202) echo "IndexNow accepted." ;;
+            *) echo "::warning::IndexNow returned $code (non-fatal; Bing still crawls via the sitemap)." ;;
+          esac
 
   deploy-ingest:
     name: ingest/data stack (SAM, us-west-2)

--- a/docs/issues/HLW-043-indexnow.md
+++ b/docs/issues/HLW-043-indexnow.md
@@ -1,0 +1,34 @@
+# HLW-043: IndexNow ping on deploy (instant Bing/Yandex recrawl)
+
+- **Status:** in-progress (built; in PR)
+- **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/77
+- **Branch:** `feat/HLW-043-indexnow`
+- **Created:** 2026-08-24
+
+## Summary
+
+On each **site** deploy, ping IndexNow so Bing / Yandex (and other participating engines)
+re-crawl the changed pages immediately instead of waiting for the periodic sitemap crawl.
+Google does **not** support IndexNow — it still relies on the sitemap + Search Console.
+
+## How
+
+- `web/23b65e54-…​.txt` — the IndexNow ownership key file (a UUID; public, hosted at the
+  site root so engines can verify the key).
+- `.github/workflows/deploy.yml` — new step in the `deploy-site` job (after the CloudFront
+  invalidation): POSTs the sitemap's `<loc>` URLs to `https://api.indexnow.org/indexnow`
+  with `host` + `key` + `keyLocation`. **Best-effort** — a non-2xx is a `::warning::`, never
+  fails the deploy.
+- SW `CACHE` → v37 (the key file is a `web/` change); `RELEASE` unchanged (silent).
+
+## Notes
+
+- Key is in UUID form so its longest hex run (12) stays under the secret-scan's 30-char threshold.
+- Submits the full sitemap URL set on each site deploy (3 URLs) — simple and within IndexNow norms.
+- Runs only on `deploy-site`, i.e. when `web/` changed.
+
+## Acceptance
+
+- [x] `deploy.yml` valid YAML; JSON body builds correctly from the local sitemap.
+- [ ] CI green.
+- [ ] After a deploy: the IndexNow step returns 200/202; Bing's URL-submission view shows the pings.

--- a/web/23b65e54-7ebe-45ca-aff4-d9fbe16c00e8.txt
+++ b/web/23b65e54-7ebe-45ca-aff4-d9fbe16c00e8.txt
@@ -1,0 +1,1 @@
+23b65e54-7ebe-45ca-aff4-d9fbe16c00e8

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,5 +1,5 @@
 /* Havasu Lake Weather — service worker (installability + offline shell) */
-const CACHE = "havasu-wx-v36";  // bump on EVERY web/ change (cache correctness; CI-enforced)
+const CACHE = "havasu-wx-v37";  // bump on EVERY web/ change (cache correctness; CI-enforced)
 const RELEASE = "r1";           // bump ONLY for user-facing changes — drives the "update available" toast
 const SHELL = [
   "/", "/index.html", "/water.html", "/radar.html", "/manifest.json", "/sw-register.js",


### PR DESCRIPTION
Closes #77. On each **site** deploy, ping IndexNow so **Bing / Yandex** re-crawl changed pages within minutes instead of waiting on the periodic sitemap crawl. (Google doesn't support IndexNow — it keeps using the sitemap + GSC.)

## Changes
- **`web/23b65e54-…​.txt`** — IndexNow ownership key file (a UUID; public, hosted at the site root so engines can verify the key).
- **`.github/workflows/deploy.yml`** — new step in the `deploy-site` job (after the CloudFront invalidation): POSTs the sitemap's `<loc>` URLs to `https://api.indexnow.org/indexnow` with `host` + `key` + `keyLocation`. **Best-effort** — a non-2xx is a `::warning::`, never fails the deploy.
- SW `CACHE` → **v37**; **`RELEASE` unchanged** → deploys silently.

## Validated locally
- `deploy.yml` parses; JSON body builds correctly from the sitemap (3 URLs, right keyLocation); secret-scan clean (UUID key stays under the hex threshold).

## After merge
The site deploy this PR triggers will fire the first ping (the key file is synced to S3 in the same job, just before the ping). You can confirm in **Bing Webmaster Tools → URL submission / IndexNow**. Runs on every future `web/` deploy automatically.