### PR TITLE
HLW-044: dual temperature — Solar Shielded (WH31E) + Full Sun

### DIFF
--- a/docs/issues/HLW-028-wh31e-air-temp.md
+++ b/docs/issues/HLW-028-wh31e-air-temp.md
@@ -1,6 +1,6 @@
 # HLW-028: WH31E shaded air temp — provision, verify, dual-temp display
 
-- **Status:** in-progress (Phase 1 — provision & verify)
+- **Status:** in-progress — Phase 1 (provision & verify) **DONE** 2026-08-26; Phase 2 waiting on the radiation shield.
 - **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/79
 - **Branch:** `feat/HLW-028-wh31e-air-temp`
 - **PR:** _(opens with Phase 2 code)_
@@ -9,7 +9,7 @@
 ## Summary
 
 Add the new **WH31E** wireless thermo-hygrometer (paired to the WS-2902D console on
-**CH1** → `temp1f` / `humidity1f` / `batt1`) as a shade-shielded **true air temperature**,
+**CH1** → `temp1f` / `humidity1` / `batt1`) as a shade-shielded **true air temperature**,
 while keeping the existing all-in-one array temp as the **"in the sun"** reading. Both
 temps stay available.
 
@@ -30,21 +30,25 @@ useful at a lake (dock/deck feel), so we surface both rather than replace one wi
 
 The ingest Lambda stores **every** posted field (no allow-list; only indoor
 `tempinf`/`humidityin`/`battin` + `PASSKEY`/`dateutc` are dropped — `handler.js:96-99`),
-so once the WH31E is paired, `temp1f`/`humidity1f`/`batt1` land in DynamoDB automatically —
+so once the WH31E is paired, `temp1f`/`humidity1`/`batt1` land in DynamoDB automatically —
 stored as *strings* (they're not in the `NUMERIC` set) — with **no code change and no
 deploy**. Nothing live reads those fields, so pairing can't break anything.
 
-- [ ] Pair WH31E to the console on **CH1**; let it transmit a few minutes.
-- [ ] Confirm the extra sensor appears in the Ambient Weather Network app.
-- [ ] Confirm `temp1f`/`humidity1f` are present on the newest `OBS#…` DynamoDB item
-      (read-only `dynamodb query`, no deploy).
-- [ ] Sanity-check WH31E vs array `tempf` — close in shade; array reads high in sun.
+- [x] Pair WH31E to the console on **CH1**; let it transmit a few minutes.
+- [x] Confirm `temp1f`/`humidity1`/`batt1` are present on the newest `OBS#…` DynamoDB
+      item (read-only `dynamodb query`, no deploy). **Verified 2026-08-26** — CH1 began
+      landing at `2026-08-27T00:35:33Z` (UTC) and has appeared on **every** reading since
+      (~1/min), not intermittently.
+- [x] Sanity-check WH31E vs array `tempf`. Sensor sitting **indoors** at check time:
+      `temp1f` ≈ 85°F, `humidity1` ≈ 30%, `batt1` = 1 (OK), vs array `tempf` ≈ 116°F —
+      the ~30° gap confirms two independent sensors. (Will move to shade by the station
+      next, then into the shield when it arrives.)
 
 ### Phase 2 — dual temp (gated on radiation shield arriving + Phase 1 good)
 
 Normal `feat/HLW-028` branch → PR → Chad merges (merge = deploy).
 
-- [ ] `handler.js`: add `temp1f`/`humidity1f`/`batt1` to `NUMERIC` (store as numbers;
+- [ ] `handler.js`: add `temp1f`/`humidity1`/`batt1` to `NUMERIC` (store as numbers;
       old string-typed items coerced defensively on read).
 - [ ] `read.js` `/api/current`: keep `temperatureF` (array), add `shadeTempF` (WH31E).
 - [ ] `index.html`: primary big number = shaded air temp, "in the sun" chip = array temp;
@@ -55,13 +59,17 @@ Normal `feat/HLW-028` branch → PR → Chad merges (merge = deploy).
 
 ## Acceptance criteria
 
-- [ ] Phase 1: WH31E data is visible in DynamoDB and reads sensibly vs the array.
+- [x] Phase 1: WH31E data is visible in DynamoDB and reads sensibly vs the array.
 - [ ] Phase 2: the site shows both a shaded air temp and an "in the sun" temp; `npm test` green.
 
 ## Notes
 
 - Channel → field mapping: the WH31E's channel dial (1–8) sets which `tempNf`/`humidityN`/
-  `battN` it posts. **CH1 → `temp1f` / `humidity1f` / `batt1`.** `battN` is 1 = OK, 0 = low.
+  `battN` it posts. **CH1 → `temp1f` / `humidity1` / `batt1`.** `battN` is 1 = OK, 0 = low.
 - The WS-2902D console supports up to 8 WH31 sensors, so more channels can be added later.
 - Radiation shield is a hard prerequisite for the Phase 2 cutover — without it the WH31E
   also reads high in sun and there's no accuracy win over the array.
+- **Field-name correction (from Phase 1):** extra-sensor humidity posts as **`humidity1`**
+  (no `f`), not `humidity1f`; temp is `temp1f`, battery `batt1`. All three currently land
+  as **strings** (not in the ingest `NUMERIC` set) — harmless (nothing live reads them),
+  and Phase 2 will number-cast them and coerce old string items defensively on read.

--- a/docs/issues/HLW-028-wh31e-air-temp.md
+++ b/docs/issues/HLW-028-wh31e-air-temp.md
@@ -1,6 +1,6 @@
 # HLW-028: WH31E shaded air temp — provision, verify, dual-temp display
 
-- **Status:** in-progress — Phase 1 (provision & verify) **DONE** 2026-08-26; Phase 2 waiting on the radiation shield.
+- **Status:** in-progress — Phase 1 **DONE** 2026-08-26. Phase 2 (dual-temp UI) **built + previewed** 2026-08-26, PR open; the live deploy stays gated on the radiation shield arriving + Chad's merge.
 - **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/79
 - **Branch:** `feat/HLW-028-wh31e-air-temp`
 - **PR:** _(opens with Phase 2 code)_
@@ -48,19 +48,21 @@ deploy**. Nothing live reads those fields, so pairing can't break anything.
 
 Normal `feat/HLW-028` branch → PR → Chad merges (merge = deploy).
 
-- [ ] `handler.js`: add `temp1f`/`humidity1`/`batt1` to `NUMERIC` (store as numbers;
-      old string-typed items coerced defensively on read).
-- [ ] `read.js` `/api/current`: keep `temperatureF` (array), add `shadeTempF` (WH31E).
-- [ ] `index.html`: primary big number = shaded air temp, "in the sun" chip = array temp;
-      bump SW cache (`havasu-wx-vN`).
-- [ ] Decide with the Phase 2 plan: does feels-like / dew point switch to the shaded
-      sensor's temp+humidity? Does the history chart get a second line?
-- [ ] Tests for the numeric parsing + read shaping.
+- [x] `handler.js`: `temp1f`/`humidity1`/`batt1` added to `NUMERIC` (future writes store as
+      numbers; `read.js` coerces old string items via `toNum`).
+- [x] `read.js`: `/api/current` adds `shadeTempF`/`shadeHumidity`/`shadeFeelsLikeF`/`shadeDewPointF`
+      (array `temperatureF` kept as "Full Sun"); `shadeTempF` also added to `/api/history` and `/api/compare`.
+- [x] `index.html`: hero = **Solar Shielded** primary + smaller **Full Sun** secondary; 24h Range
+      keyed to the shielded series; **dual-line** history chart (Shielded + Full Sun) with legend +
+      single-line fallback; Station check shows Temp (shade) + Temp (sun), both vs the neighbor. SW → `v31`.
+- [x] Decisions: feels-like follows the shielded primary; dew point + humidity stay on the array
+      (shielded/array humidity match closely); history chart got the second line. Primary caption: "SOLAR SHIELDED".
+- [x] Tests: `ingest/test/read.test.mjs` covers `toNum` coercion; `npm test` 57/57 green.
 
 ## Acceptance criteria
 
 - [x] Phase 1: WH31E data is visible in DynamoDB and reads sensibly vs the array.
-- [ ] Phase 2: the site shows both a shaded air temp and an "in the sun" temp; `npm test` green.
+- [x] Phase 2 (built): the page shows both a shielded air temp and a Full Sun temp; `npm test` 57/57 green. Live cutover pends the shield + merge.
 
 ## Notes
 

--- a/docs/issues/HLW-028-wh31e-air-temp.md
+++ b/docs/issues/HLW-028-wh31e-air-temp.md
@@ -1,0 +1,67 @@
+# HLW-028: WH31E shaded air temp — provision, verify, dual-temp display
+
+- **Status:** in-progress (Phase 1 — provision & verify)
+- **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/79
+- **Branch:** `feat/HLW-028-wh31e-air-temp`
+- **PR:** _(opens with Phase 2 code)_
+- **Created:** 2026-08-26
+
+## Summary
+
+Add the new **WH31E** wireless thermo-hygrometer (paired to the WS-2902D console on
+**CH1** → `temp1f` / `humidity1f` / `batt1`) as a shade-shielded **true air temperature**,
+while keeping the existing all-in-one array temp as the **"in the sun"** reading. Both
+temps stay available.
+
+The solar radiation shield hasn't arrived yet — and the shield is what makes the WH31E a
+trustworthy air temp — so this is split into a verify-first phase (now, no deploy) and the
+display cutover (later, gated on the shield + Phase 1 looking good).
+
+## Motivation / context
+
+The WS-2902 all-in-one array isn't aspirated and reads high in direct sun, so "current
+temp" on the site currently drifts warm on sunny afternoons. A shaded WH31E gives a real
+air temperature; keeping the array reading as an explicit "in the sun" number is actually
+useful at a lake (dock/deck feel), so we surface both rather than replace one with the other.
+
+## Plan
+
+### Phase 1 — provision & verify (no deploy)
+
+The ingest Lambda stores **every** posted field (no allow-list; only indoor
+`tempinf`/`humidityin`/`battin` + `PASSKEY`/`dateutc` are dropped — `handler.js:96-99`),
+so once the WH31E is paired, `temp1f`/`humidity1f`/`batt1` land in DynamoDB automatically —
+stored as *strings* (they're not in the `NUMERIC` set) — with **no code change and no
+deploy**. Nothing live reads those fields, so pairing can't break anything.
+
+- [ ] Pair WH31E to the console on **CH1**; let it transmit a few minutes.
+- [ ] Confirm the extra sensor appears in the Ambient Weather Network app.
+- [ ] Confirm `temp1f`/`humidity1f` are present on the newest `OBS#…` DynamoDB item
+      (read-only `dynamodb query`, no deploy).
+- [ ] Sanity-check WH31E vs array `tempf` — close in shade; array reads high in sun.
+
+### Phase 2 — dual temp (gated on radiation shield arriving + Phase 1 good)
+
+Normal `feat/HLW-028` branch → PR → Chad merges (merge = deploy).
+
+- [ ] `handler.js`: add `temp1f`/`humidity1f`/`batt1` to `NUMERIC` (store as numbers;
+      old string-typed items coerced defensively on read).
+- [ ] `read.js` `/api/current`: keep `temperatureF` (array), add `shadeTempF` (WH31E).
+- [ ] `index.html`: primary big number = shaded air temp, "in the sun" chip = array temp;
+      bump SW cache (`havasu-wx-vN`).
+- [ ] Decide with the Phase 2 plan: does feels-like / dew point switch to the shaded
+      sensor's temp+humidity? Does the history chart get a second line?
+- [ ] Tests for the numeric parsing + read shaping.
+
+## Acceptance criteria
+
+- [ ] Phase 1: WH31E data is visible in DynamoDB and reads sensibly vs the array.
+- [ ] Phase 2: the site shows both a shaded air temp and an "in the sun" temp; `npm test` green.
+
+## Notes
+
+- Channel → field mapping: the WH31E's channel dial (1–8) sets which `tempNf`/`humidityN`/
+  `battN` it posts. **CH1 → `temp1f` / `humidity1f` / `batt1`.** `battN` is 1 = OK, 0 = low.
+- The WS-2902D console supports up to 8 WH31 sensors, so more channels can be added later.
+- Radiation shield is a hard prerequisite for the Phase 2 cutover — without it the WH31E
+  also reads high in sun and there's no accuracy win over the array.

--- a/docs/issues/HLW-028-wh31e-air-temp.md
+++ b/docs/issues/HLW-028-wh31e-air-temp.md
@@ -3,7 +3,7 @@
 - **Status:** in-progress — Phase 1 **DONE** 2026-08-26. Phase 2 (dual-temp UI) **built + previewed** 2026-08-26, PR open; the live deploy stays gated on the radiation shield arriving + Chad's merge.
 - **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/79
 - **Branch:** `feat/HLW-028-wh31e-air-temp`
-- **PR:** _(opens with Phase 2 code)_
+- **PR:** https://github.com/cwoskoski/havasulakeweather/pull/80 (draft — merge/deploy gated on the shield)
 - **Created:** 2026-08-26
 
 ## Summary

--- a/docs/issues/HLW-044-wh31e-air-temp.md
+++ b/docs/issues/HLW-044-wh31e-air-temp.md
@@ -1,9 +1,9 @@
-# HLW-028: WH31E shaded air temp — provision, verify, dual-temp display
+# HLW-044: WH31E shaded air temp — provision, verify, dual-temp display
 
 - **Status:** in-progress — Phase 1 **DONE** 2026-08-26. Phase 2 (dual-temp UI) **built + previewed** 2026-08-26, PR open; the live deploy stays gated on the radiation shield arriving + Chad's merge.
 - **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/79
-- **Branch:** `feat/HLW-028-wh31e-air-temp`
-- **PR:** https://github.com/cwoskoski/havasulakeweather/pull/80 (draft — merge/deploy gated on the shield)
+- **Branch:** `feat/HLW-044-wh31e-air-temp`
+- **PR:** _(renumbered from HLW-028; new draft PR below)_
 - **Created:** 2026-08-26
 
 ## Summary
@@ -46,7 +46,7 @@ deploy**. Nothing live reads those fields, so pairing can't break anything.
 
 ### Phase 2 — dual temp (gated on radiation shield arriving + Phase 1 good)
 
-Normal `feat/HLW-028` branch → PR → Chad merges (merge = deploy).
+Normal `feat/HLW-044` branch → PR → Chad merges (merge = deploy).
 
 - [x] `handler.js`: `temp1f`/`humidity1`/`batt1` added to `NUMERIC` (future writes store as
       numbers; `read.js` coerces old string items via `toNum`).
@@ -54,7 +54,7 @@ Normal `feat/HLW-028` branch → PR → Chad merges (merge = deploy).
       (array `temperatureF` kept as "Full Sun"); `shadeTempF` also added to `/api/history` and `/api/compare`.
 - [x] `index.html`: hero = **Solar Shielded** primary + smaller **Full Sun** secondary; 24h Range
       keyed to the shielded series; **dual-line** history chart (Shielded + Full Sun) with legend +
-      single-line fallback; Station check shows Temp (shade) + Temp (sun), both vs the neighbor. SW → `v31`.
+      single-line fallback; Station check shows Temp (shade) + Temp (sun), both vs the neighbor. SW → `v38` + `RELEASE` r2 (user-facing → update toast).
 - [x] Decisions: feels-like follows the shielded primary; dew point + humidity stay on the array
       (shielded/array humidity match closely); history chart got the second line. Primary caption: "SOLAR SHIELDED".
 - [x] Tests: `ingest/test/read.test.mjs` covers `toNum` coercion; `npm test` 57/57 green.
@@ -75,3 +75,7 @@ Normal `feat/HLW-028` branch → PR → Chad merges (merge = deploy).
   (no `f`), not `humidity1f`; temp is `temp1f`, battery `batt1`. All three currently land
   as **strings** (not in the ingest `NUMERIC` set) — harmless (nothing live reads them),
   and Phase 2 will number-cast them and coerce old string items defensively on read.
+- **Renumbered HLW-028 → HLW-044:** the branch was first opened off a stale local `main`
+  and given HLW-028, which was already the merged SEO ticket (`HLW-028-seo-improvements.md`).
+  Rebased onto the real `origin/main` (HLW-043 was the latest; 044 is the next free number),
+  the ticket/branch/issue/PR renumbered to HLW-044, and SW re-bumped over the real `v37`.

--- a/docs/issues/HLW-044-wh31e-air-temp.md
+++ b/docs/issues/HLW-044-wh31e-air-temp.md
@@ -3,7 +3,7 @@
 - **Status:** in-progress — Phase 1 **DONE** 2026-08-26. Phase 2 (dual-temp UI) **built + previewed** 2026-08-26, PR open; the live deploy stays gated on the radiation shield arriving + Chad's merge.
 - **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/79
 - **Branch:** `feat/HLW-044-wh31e-air-temp`
-- **PR:** _(renumbered from HLW-028; new draft PR below)_
+- **PR:** https://github.com/cwoskoski/havasulakeweather/pull/81 (draft — merge/deploy gated on the shield; supersedes #80)
 - **Created:** 2026-08-26
 
 ## Summary

--- a/ingest/src/handler.js
+++ b/ingest/src/handler.js
@@ -32,6 +32,8 @@ const NUMERIC = new Set([
   "uv", "solarradiation", "hourlyrainin", "eventrainin", "dailyrainin",
   "weeklyrainin", "monthlyrainin", "yearlyrainin", "totalrainin",
   "baromrelin", "baromabsin", "battout",
+  // WH31E extra thermo-hygrometer, CH1 (shaded air temp). battN: 1 = OK, 0 = low.
+  "temp1f", "humidity1", "batt1",
 ]);
 
 // In-memory watermark, survives across warm invocations (~1/min keeps us warm):

--- a/ingest/src/read.js
+++ b/ingest/src/read.js
@@ -40,6 +40,9 @@ function res(status, body, cacheSeconds = 15) {
 
 const COMPASS = ["N", "NNE", "NE", "ENE", "E", "ESE", "SE", "SSE", "S", "SSW", "SW", "WSW", "W", "WNW", "NW", "NNW"];
 const compass = (deg) => (deg == null ? null : COMPASS[Math.round((deg % 360) / 22.5) % 16]);
+// Extra-sensor fields (WH31E CH1) currently store as strings — coerce, null if absent/bad.
+// Note null/undefined/"" -> null (not 0, which Number() would give for null/"").
+export const toNum = (v) => { if (v == null || v === "") return null; const n = Number(v); return Number.isFinite(n) ? n : null; };
 
 function dewPointF(tf, rh) {
   if (tf == null || rh == null || rh <= 0) return null;
@@ -87,7 +90,7 @@ async function series(hours) {
         TableName: TABLE,
         KeyConditionExpression: "pk = :pk AND sk >= :s",
         ExpressionAttributeValues: { ":pk": obsPk(mm), ":s": startISO },
-        ProjectionExpression: "sk, tempf, windspeedmph, windgustmph, winddir, humidity, baromrelin, uv, solarradiation, dailyrainin",
+        ProjectionExpression: "sk, tempf, temp1f, windspeedmph, windgustmph, winddir, humidity, baromrelin, uv, solarradiation, dailyrainin",
         ExclusiveStartKey: ek,
       }));
       items.push(...(r.Items || []));
@@ -141,6 +144,10 @@ export const handler = async (event) => {
       const it = await newest();
       if (!it) return res(200, { station: STATION, reading: null }, 15);
       const tf = it.tempf, rh = it.humidity;
+      // WH31E shaded thermo-hygrometer (CH1). Primary "air temp" on the page when it's
+      // reporting; the all-in-one array (tf) becomes the "Full Sun" reading. Null when
+      // the extra sensor drops out, so the page can fall back to the array.
+      const shadeTf = toNum(it.temp1f), shadeRh = toNum(it.humidity1);
       const ageSec = it.receivedAt ? (Date.now() - Date.parse(it.receivedAt)) / 1000 : null;
       const rain = rainState(await rainWindow(RAIN_DEBOUNCE_MIN), it);
       return res(200, {
@@ -152,6 +159,10 @@ export const handler = async (event) => {
         feelsLikeF: feelsLikeF(tf, rh, it.windspeedmph),
         humidity: rh,
         dewPointF: dewPointF(tf, rh),
+        shadeTempF: shadeTf,
+        shadeHumidity: shadeRh,
+        shadeFeelsLikeF: shadeTf != null ? feelsLikeF(shadeTf, shadeRh, it.windspeedmph) : null,
+        shadeDewPointF: shadeTf != null ? dewPointF(shadeTf, shadeRh) : null,
         wind: { speedMph: it.windspeedmph, gustMph: it.windgustmph, maxDailyGustMph: it.maxdailygust, directionDeg: it.winddir, compass: compass(it.winddir) },
         pressureInHg: it.baromrelin,
         uv: it.uv,
@@ -168,7 +179,7 @@ export const handler = async (event) => {
       return res(200, {
         station: STATION, hours, count: its.length,
         points: its.map((r) => ({
-          t: r.sk, tempF: r.tempf, windMph: r.windspeedmph, gustMph: r.windgustmph,
+          t: r.sk, tempF: r.tempf, shadeTempF: toNum(r.temp1f), windMph: r.windspeedmph, gustMph: r.windgustmph,
           dirDeg: r.winddir, humidity: r.humidity, pressureInHg: r.baromrelin,
           uv: r.uv, solarWm2: r.solarradiation, rainTodayIn: r.dailyrainin,
         })),
@@ -206,7 +217,7 @@ export const handler = async (event) => {
             const ageSec = it.receivedAt ? (Date.now() - Date.parse(it.receivedAt)) / 1000 : null;
             mine = {
               id: STATION, label: "Havasu Lake (mine)",
-              tempF: it.tempf, windMph: it.windspeedmph, humidity: it.humidity,
+              tempF: it.tempf, shadeTempF: toNum(it.temp1f), windMph: it.windspeedmph, humidity: it.humidity,
               pressureInHg: it.baromrelin, rainTodayIn: it.dailyrainin,
               observedAt: it.dateutc, stale: ageSec != null && ageSec > 600,
             };

--- a/ingest/test/read.test.mjs
+++ b/ingest/test/read.test.mjs
@@ -1,0 +1,31 @@
+// Unit tests for toNum(v) from ingest/src/read.js. Pure logic, no AWS/network.
+// toNum coerces the WH31E extra-sensor fields (temp1f/humidity1/batt1), which the
+// ingest currently stores as STRINGS, back to numbers for the API — returning null
+// (not 0) when the sensor is absent, so the page falls back to the array.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { toNum } from "../src/read.js";
+
+test("toNum: numeric string -> number", () => {
+  assert.equal(toNum("112.1"), 112.1);
+  assert.equal(toNum("16"), 16);
+  assert.equal(toNum("-3.5"), -3.5);
+});
+
+test("toNum: number passes through", () => {
+  assert.equal(toNum(98), 98);
+  assert.equal(toNum(0), 0);
+});
+
+test("toNum: absent/empty -> null (never 0)", () => {
+  // DynamoDB returns undefined for a missing attribute; guard null/"" too, since
+  // Number(null) and Number("") are 0 and would fake a 0°F reading.
+  assert.equal(toNum(undefined), null);
+  assert.equal(toNum(null), null);
+  assert.equal(toNum(""), null);
+});
+
+test("toNum: non-numeric -> null", () => {
+  assert.equal(toNum("abc"), null);
+  assert.equal(toNum("NaN"), null);
+});

--- a/web/index.html
+++ b/web/index.html
@@ -140,6 +140,13 @@
   .big.teal .deg{color:var(--teal);}
   .head-sub{margin-top:5px;font-size:.92rem;font-weight:650;color:var(--ink-soft);}
   .head-sub b{color:var(--ink);font-weight:800;}
+  /* Dual temperature: shade (primary) + full sun (secondary) */
+  .temp-row{display:flex;align-items:flex-end;gap:16px;flex-wrap:wrap;}
+  .temp-primary{display:flex;flex-direction:column;}
+  .sun-temp{display:flex;flex-direction:column;padding-bottom:3px;}
+  .big-sun{font-size:1.85rem;font-weight:800;line-height:.95;letter-spacing:-.5px;color:var(--teal-deep);}
+  .big-sun .deg-sun{font-size:1rem;color:var(--teal);vertical-align:top;}
+  .temp-cap{margin-top:3px;font-size:.66rem;font-weight:800;letter-spacing:.6px;text-transform:uppercase;color:var(--ink-soft);}
   .compass{width:58px;height:58px;flex:none;}
   #windArrow{transition:transform .6s cubic-bezier(.2,.8,.2,1);transform-box:view-box;transform-origin:30px 30px;}
 
@@ -195,6 +202,11 @@
   .range-tabs button{border:1px solid var(--glass-brd);background:rgba(255,255,255,.28);color:var(--ink-soft);font:inherit;font-family:var(--font);font-weight:800;font-size:.72rem;padding:5px 11px;border-radius:999px;cursor:pointer;}
   .range-tabs button.on{background:linear-gradient(160deg,rgba(255,122,69,.3),rgba(255,255,255,.2));border-color:var(--coral);color:var(--coral-deep);}
   .chart svg{display:block;width:100%;height:auto;}
+  .chart-legend{display:flex;gap:16px;padding:0 4px 10px;}
+  .chart-legend .lg{display:inline-flex;align-items:center;gap:6px;font-size:.72rem;font-weight:800;color:var(--ink-soft);}
+  .chart-legend .lg i{width:15px;height:3px;border-radius:2px;display:inline-block;}
+  .chart-legend .lg-shade i{background:var(--coral-deep);}
+  .chart-legend .lg-sun i{background:var(--teal-deep);}
 
   /* ---- support / donate ---- */
   .support{padding:18px 18px 16px;text-align:center;background:linear-gradient(160deg,rgba(255,180,90,.28),rgba(255,255,255,.12)),var(--glass-bg-2);border:1px solid rgba(255,255,255,.55);}
@@ -421,7 +433,16 @@
           </span>
           <div class="head-main">
             <div class="head-label">Temperature</div>
-            <div class="big"><span id="temp">--</span><span class="deg">&deg;F</span></div>
+            <div class="temp-row">
+              <div class="temp-primary">
+                <div class="big"><span id="temp">--</span><span class="deg">&deg;F</span></div>
+                <div class="temp-cap" id="tempCap" hidden>Solar Shielded</div>
+              </div>
+              <div class="sun-temp" id="sunTemp" hidden>
+                <div class="big-sun"><span id="tempSun">--</span><span class="deg-sun">&deg;</span></div>
+                <div class="temp-cap">Full Sun</div>
+              </div>
+            </div>
             <div class="head-sub">Feels like <b id="feels">--&deg;F</b></div>
           </div>
         </div>
@@ -547,6 +568,10 @@
           <button type="button" data-hours="168">7d</button>
         </div>
       </div>
+      <div class="chart-legend" id="chartLegend" hidden>
+        <span class="lg lg-shade"><i></i>Solar Shielded</span>
+        <span class="lg lg-sun"><i></i>Full Sun</span>
+      </div>
       <svg id="chartSvg" viewBox="0 0 700 262" role="img" aria-label="Temperature over time">
         <defs>
           <linearGradient id="tempFill" x1="0" y1="0" x2="0" y2="1">
@@ -560,6 +585,7 @@
         </defs>
         <g id="chartGrid" stroke="rgba(43,24,16,0.12)" stroke-width="1"></g>
         <path id="chartArea" fill="url(#tempFill)" d=""/>
+        <path id="chartLine2" fill="none" stroke="#0f7f8f" stroke-width="2.2" stroke-opacity="0.85" stroke-linejoin="round" stroke-linecap="round" d=""/>
         <path id="chartLine" fill="none" stroke="url(#tempLine)" stroke-width="3.2" stroke-linejoin="round" stroke-linecap="round" d=""/>
         <g id="chartLabels" fill="rgba(43,24,16,0.55)" font-size="11" font-weight="700" font-family="sans-serif"></g>
       </svg>
@@ -665,8 +691,16 @@
       var r=await fetch(API+"/api/current",{cache:"no-store"});
       var d=await r.json();
       if(!d||d.temperatureF==null){$("freshText").textContent="Waiting for data…";return;}
-      set("temp",Math.round(d.temperatureF));
-      set("feels",Math.round(d.feelsLikeF)+"°F");
+      /* Shaded WH31E is the primary "air temp" when present; the array becomes "Full Sun". */
+      var hasShade=d.shadeTempF!=null;
+      var primaryTemp=hasShade?d.shadeTempF:d.temperatureF;
+      var primaryFeels=(hasShade&&d.shadeFeelsLikeF!=null)?d.shadeFeelsLikeF:d.feelsLikeF;
+      set("temp",Math.round(primaryTemp));
+      set("feels",Math.round(primaryFeels)+"°F");
+      $("tempCap").hidden=!hasShade;
+      var sun=$("sunTemp");
+      if(hasShade){set("tempSun",Math.round(d.temperatureF));sun.hidden=false;}
+      else{sun.hidden=true;}
       set("wind",Math.round(d.wind.speedMph));
       set("gust",Math.round(d.wind.gustMph)+" mph");
       set("windDir",(d.wind.compass||"—")+" ("+Math.round(d.wind.directionDeg)+"°)");
@@ -714,13 +748,16 @@
       var r=await fetch(API+"/api/history?hours="+hours,{cache:"no-store"});
       var d=await r.json();
       var pts=(d.points||[]).filter(function(p){return typeof p.tempF==="number";});
-      drawChart(pts,hours);
-      if(pts.length){
-        var temps=pts.map(function(p){return p.tempF;});
-        set("hi",Math.round(Math.max.apply(null,temps)));
-        set("lo",Math.round(Math.min.apply(null,temps)));
-        trend(pts);
+      var shadePts=pts.filter(function(p){return typeof p.shadeTempF==="number";});
+      drawChart(pts,shadePts,hours);
+      /* 24h Range keys to the shielded series (matches the headline) when we have it. */
+      var rangeVals=shadePts.length?shadePts.map(function(p){return p.shadeTempF;})
+                                   :pts.map(function(p){return p.tempF;});
+      if(rangeVals.length){
+        set("hi",Math.round(Math.max.apply(null,rangeVals)));
+        set("lo",Math.round(Math.min.apply(null,rangeVals)));
       }
+      if(pts.length){trend(pts);}
     }catch(e){}
   }
   function trend(pts){
@@ -732,22 +769,38 @@
     else if(dp<-0.02){el.textContent="▼ Falling";el.className="chip falling";el.style.color="";el.style.background="";}
     else{el.textContent="Steady";el.className="chip";el.style.color="var(--ink-soft)";el.style.background="rgba(43,24,16,.1)";}
   }
-  function drawChart(pts,hours){
-    var grid=$("chartGrid"),labels=$("chartLabels");
+  function drawChart(sunPts,shadePts,hours){
+    var grid=$("chartGrid"),labels=$("chartLabels"),legend=$("chartLegend");
+    var line=$("chartLine"),line2=$("chartLine2"),area=$("chartArea");
     grid.innerHTML="";labels.innerHTML="";
-    if(pts.length<2){$("chartLine").setAttribute("d","");$("chartArea").setAttribute("d","");return;}
-    var temps=pts.map(function(p){return p.tempF;});
-    var lo=Math.min.apply(null,temps),hi=Math.max.apply(null,temps);
+    if(sunPts.length<2){line.setAttribute("d","");line2.setAttribute("d","");area.setAttribute("d","");legend.hidden=true;return;}
+    var dual=shadePts.length>=2;
+    /* Y-scale spans whichever series are shown. */
+    var vals=sunPts.map(function(p){return p.tempF;});
+    if(dual){vals=vals.concat(shadePts.map(function(p){return p.shadeTempF;}));}
+    var lo=Math.min.apply(null,vals),hi=Math.max.apply(null,vals);
     var pad=Math.max(2,(hi-lo)*0.12);lo-=pad;hi+=pad;
-    var t0=Date.parse(pts[0].t),t1=Date.parse(pts[pts.length-1].t);
+    /* X domain from the full (sun) series so the time axis is always complete. */
+    var t0=Date.parse(sunPts[0].t),t1=Date.parse(sunPts[sunPts.length-1].t);
     var span=Math.max(1,t1-t0);
     function X(t){return 10+((Date.parse(t)-t0)/span)*(W-20);}
     function Y(v){return PAD_T+(1-(v-lo)/Math.max(1,(hi-lo)))*(H-PAD_T-PAD_B);}
-    var dLine="",dArea="";
-    pts.forEach(function(p,i){var x=X(p.t).toFixed(1),y=Y(p.tempF).toFixed(1);dLine+=(i?"L":"M")+x+","+y+" ";});
-    dArea=dLine+"L"+X(pts[pts.length-1].t).toFixed(1)+","+(H-PAD_B)+" L"+X(pts[0].t).toFixed(1)+","+(H-PAD_B)+" Z";
-    $("chartLine").setAttribute("d",dLine.trim());
-    $("chartArea").setAttribute("d",dArea);
+    function path(arr,key){var d="";arr.forEach(function(p,i){d+=(i?"L":"M")+X(p.t).toFixed(1)+","+Y(p[key]).toFixed(1)+" ";});return d.trim();}
+    var sunLine=path(sunPts,"tempF");
+    if(dual){
+      /* Primary = shielded (coral, drawn on top); secondary = full sun (teal); no fill. */
+      line.setAttribute("d",path(shadePts,"shadeTempF"));line.setAttribute("stroke","#e8451f");
+      line2.setAttribute("d",sunLine);
+      area.setAttribute("d","");
+      legend.hidden=false;
+    }else{
+      /* Fallback: single full-sun line in the original gradient + fill. */
+      line.setAttribute("d",sunLine);line.setAttribute("stroke","url(#tempLine)");
+      line2.setAttribute("d","");
+      var last=sunPts[sunPts.length-1];
+      area.setAttribute("d",sunLine+"L"+X(last.t).toFixed(1)+","+(H-PAD_B)+" L"+X(sunPts[0].t).toFixed(1)+","+(H-PAD_B)+" Z");
+      legend.hidden=true;
+    }
     /* gridlines at hi/mid/lo */
     [hi-pad,(hi+lo)/2,lo+pad].forEach(function(v){
       var y=Y(v);
@@ -868,16 +921,21 @@
     if(d.configured===false||!mine||!near){sec.hidden=true;return;} // hidden until WU key is set
     sec.hidden=false;
     $("cmpSrc").textContent=d.source==="mock"?"demo data":"vs "+(near.id||"nearby");
-    var rows=[
-      ["Temp",fnum(mine.tempF,"°"),fnum(near.tempF,"°"),fdelta(d.deltas.tempF)+"°"],
-      ["Wind",fnum(mine.windMph,""),fnum(near.windMph,""),fdelta(d.deltas.windMph)],
-      ["Humidity",fnum(mine.humidity,"%"),fnum(near.humidity,"%"),fdelta(d.deltas.humidity)],
-      ["Pressure",fnum(mine.pressureInHg,"",2),fnum(near.pressureInHg,"",2),fdelta(d.deltas.pressureInHg,2)],
-    ];
+    var rows=[];
+    /* Both our temps vs the neighbor's single (unshielded) reading. */
+    if(mine.shadeTempF!=null){
+      var shadeD=(near.tempF!=null)?(mine.shadeTempF-near.tempF):null;
+      rows.push(["Temp (shade)",fnum(mine.shadeTempF,"°"),fnum(near.tempF,"°"),fdelta(shadeD)+"°"]);
+    }
+    rows.push(["Temp (sun)",fnum(mine.tempF,"°"),fnum(near.tempF,"°"),fdelta(d.deltas.tempF)+"°"]);
+    rows.push(["Wind",fnum(mine.windMph,""),fnum(near.windMph,""),fdelta(d.deltas.windMph)]);
+    rows.push(["Humidity",fnum(mine.humidity,"%"),fnum(near.humidity,"%"),fdelta(d.deltas.humidity)]);
+    rows.push(["Pressure",fnum(mine.pressureInHg,"",2),fnum(near.pressureInHg,"",2),fdelta(d.deltas.pressureInHg,2)]);
     var html='<div class="cmp-row cmp-hdr"><span></span><span>Mine</span><span>'+esc(near.id||"Nearby")+'</span><span>&Delta;</span></div>';
     rows.forEach(function(r){html+='<div class="cmp-row"><span class="k">'+r[0]+'</span><span>'+r[1]+'</span><span>'+r[2]+'</span><span class="d">'+r[3]+'</span></div>';});
     $("cmpGrid").innerHTML=html;
-    var notes=d.notes||[];
+    var notes=(d.notes||[]).slice();
+    notes.push((near.id||"The neighbor")+" is unshielded, so Full Sun is the like-for-like drift check; the Shaded row's gap is mostly the shade effect, not station drift.");
     $("cmpNotes").innerHTML=notes.map(function(n){return '<div class="cmp-note">'+esc(n)+'</div>';}).join("");
   }
 

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,6 +1,6 @@
 /* Havasu Lake Weather — service worker (installability + offline shell) */
-const CACHE = "havasu-wx-v37";  // bump on EVERY web/ change (cache correctness; CI-enforced)
-const RELEASE = "r1";           // bump ONLY for user-facing changes — drives the "update available" toast
+const CACHE = "havasu-wx-v38";  // bump on EVERY web/ change (cache correctness; CI-enforced)
+const RELEASE = "r2";           // bump ONLY for user-facing changes — drives the "update available" toast
 const SHELL = [
   "/", "/index.html", "/water.html", "/radar.html", "/manifest.json", "/sw-register.js",
   "/assets/icon-192.png", "/assets/icon-512.png", "/assets/icon-180.png",


### PR DESCRIPTION
Refs #79. **Draft on purpose** — merge = deploy, and the deploy stays gated on the radiation shield arriving + Chad's call. Mark Ready & merge when the shield's in and it looks good live.

> Renumbered from HLW-028 (which was already the merged SEO ticket) and rebased onto the current `main`. Supersedes #80.

## What this does

Surfaces the new **WH31E** (CH1) shaded sensor as the primary **air temp** while keeping the all-in-one array as the **Full Sun** reading, across every temperature view. Built and previewed locally against real DynamoDB data (Phase 1 confirmed the sensor is flowing).

### API (`ingest/src/read.js`)
- `/api/current`: adds `shadeTempF` / `shadeHumidity` / `shadeFeelsLikeF` / `shadeDewPointF`; array `temperatureF` unchanged (the "Full Sun" value).
- `/api/history` + `/api/compare`: also return `shadeTempF`.
- New `toNum()` coerces the CH1 fields (stored as **strings** today) → number, returning **null (not 0)** when the sensor's absent so the UI can fall back.

### UI (`web/index.html`)
- **Hero:** `SOLAR SHIELDED` primary + smaller `FULL SUN` secondary; feels-like follows the shielded primary.
- **24h Range:** keyed to the shielded series (falls back to Full Sun when no shielded data).
- **Temperature history:** dual line — Shielded (coral) + Full Sun (teal) + legend; graceful single-line fallback before shielded history accrues.
- **Station check:** `Temp (shade)` + `Temp (sun)`, both vs the neighbor's single unshielded reading, with a note that Full Sun is the like-for-like drift check.
- **Fallback:** `shadeTempF` null → page reverts to array-as-primary and hides the Full Sun extras.

### Ingest / SW
- `handler.js`: `temp1f`/`humidity1`/`batt1` added to `NUMERIC`.
- SW cache `v37 → v38`; `RELEASE r1 → r2` (user-facing → update toast).

### Tests
- `ingest/test/read.test.mjs` covers `toNum`; `npm test` **57/57** green.

## Notes
- Shielded history only exists since the sensor came online, so the coral line starts partway in and the current 24h low includes the indoor→outdoor warm-up; both normalize once it has a clean day in the shield.
- Interim: sensor is in tree shade (gap ~2°, narrow partly due to overcast); the real gap opens up in the shield on a clear day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHfTY9b4p18XoeNJPactfL