### PR TITLE
HLW-045: radar future frames (HRRR +6h) + CARTO basemap fix

### DIFF
--- a/docs/issues/HLW-045-radar-future.md
+++ b/docs/issues/HLW-045-radar-future.md
@@ -1,0 +1,75 @@
+# HLW-045: Radar future frames — HRRR simulated reflectivity nowcast (+6h)
+
+- **Status:** in-progress — built + previewed locally 2026-08-27; ready for PR. Deploy gated on Chad's merge.
+- **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/82
+- **Branch:** `feat/HLW-045-radar-future`
+- **PR:** _(opens after local preview)_
+- **Created:** 2026-08-27
+
+## Summary
+
+Extend the `/radar` loop with a **+6h "future radar"** using **HRRR simulated reflectivity**
+(REFD) tiles from Iowa Environmental Mesonet (IEM) — free, keyless, standard XYZ tiles that
+slot into the existing Leaflet layers. Observed RainViewer radar (past ~2h) flows into HRRR
+model frames (now → +6h), with a **"now" divider** on the scrubber and clear "forecast (model)"
+labeling.
+
+## Motivation / context
+
+RainViewer's nowcast maxes at ~30 min and is empty in dry weather, so the current page has no
+real "next hours" prediction. HRRR simulated reflectivity gives a genuine "watch it roll in over
+the next few hours" future radar. It is a **model forecast**, not observed radar — labeled as
+such for honesty on a public community site. Skillful ~0–6h, which is why we cap at +6h.
+
+## Plan (approved: +6h, divider, small proxy)
+
+- [x] **`/api/radar` proxy** (`read.js` + `radar.js`): returns
+      `{ observed: { host, past[], nowcast[] } (RainViewer), forecast: { source, initUnix, tileTemplate, frames[] } }`.
+      Fetches the RainViewer manifest, resolves the freshest **verified** HRRR init (steps back an
+      hour if a run isn't processed yet → no 503s from unprocessed runs), and builds 30-min-step
+      frames from now → +6h. Edge-cache 5 min; soft-fails to whichever side works.
+- [x] **`web/radar.html`**: fetches `/api/radar`; renders observed (RainViewer) + forecast (IEM HRRR)
+      layers keyed by frame `kind`; **"now" divider** on the slider; gold "+Nh · forecast (model)"
+      labels to +6h; honesty note. **Throttled** to current+next layer only (IEM renders on-demand and
+      503s under a full-frame burst). Bumped SW `CACHE v39` + `RELEASE r3`.
+- [x] **CARTO basemap fix (folded in):** CARTO began gating their free raster basemap, so `/radar`
+      showed "API KEY REQUIRED" watermarks **live**. Swapped to the authenticated `rastertiles/dark_all`
+      endpoint with Chad's CARTO key (a public, domain-restricted client token).
+- [x] Local preview + screenshots; console clean (0 errors); `npm test` 61/61.
+
+## Data source
+
+`https://mesonet.agron.iastate.edu/cache/tile.py/1.0.0/hrrr::REFD-F{fmin}-{YYYYMMDDHHmm}/{z}/{x}/{y}.png`
+— 15-min steps to +18h; new run ~:50 past the hour UTC (hourly); commercial use allowed,
+attribution appreciated (IEM recommends pinning the init time, not the `-0` latest shortcut).
+
+## Acceptance criteria
+
+- [x] `/radar` animates past → now → +6h; "now" divider visible; forecast frames labeled as model.
+- [x] No new **server** secret (the CARTO basemap key is a public, domain-restricted client token);
+      radar data (RainViewer + HRRR) stays keyless. `npm test` 61/61; SW cache + release bumped.
+
+## Notes
+
+- Observed radar (RainViewer) is real; HRRR REFD is model-simulated reflectivity (a forecast).
+  UX makes the distinction obvious (divider + gold forecast tags + note).
+- Forecast step = 30 min (12 frames to +6h) — balance of smoothness vs tile load; tunable.
+- Tiles load in the browser directly from RainViewer + IEM; the proxy only returns small JSON.
+- **IEM 503s (fixed two ways):** (1) IEM only serves runs it's processed — pinning the previous
+  top-of-hour sometimes hit an unprocessed run mid-window, so the proxy now probes and steps back
+  an hour until a live run answers 200. (2) IEM's tile.py renders on-demand and 503s when hit by all
+  12 forecast frames at once — the page now keeps only the current+next layer on the map. Both
+  confirmed: console 0 errors after these.
+- **CARTO basemap key** lives in `radar.html` (public client token, fine to commit — it's not a
+  server secret). Should be **domain-restricted to havasulakeweather.com** in the CARTO dashboard.
+  Longest hex run in the key is 24 chars, so the CI 30-hex secret-scan doesn't trip.
+- **Future option:** CARTO is retiring raster basemaps in favor of vector (sharper, restyleable).
+  Migrating would mean swapping Leaflet for a GL renderer (MapLibre) — worth its own ticket later;
+  the same key already covers vector.
+- **Preview polish (from Chad's review):** (1) the time label moved to its own centered row so the
+  slider width is constant — the NOW divider no longer jumps as the label text changes width;
+  (2) frames/providers **cross-fade** (CSS opacity transition + the outgoing layer lingers one beat);
+  (3) RainViewer switched to the **NEXRAD** color scheme (`color=6`) + legend updated, so observed
+  matches HRRR's NWS green→red ramp; (4) **two-tone scrubber** — teal (observed/past) → gold
+  (forecast/future), split at NOW. Residual observed-vs-forecast differences (cyan vs lavender light
+  echoes, radar ~1km vs model ~3km) are inherent and left as a subtle real/forecast cue.

--- a/ingest/src/radar.js
+++ b/ingest/src/radar.js
@@ -1,0 +1,102 @@
+/**
+ * Havasu Lake Weather — radar manifest (HLW-045).
+ *
+ * One small JSON for the /radar page: observed radar (RainViewer, past ~2h + its
+ * short nowcast) plus a "future radar" built from HRRR simulated reflectivity
+ * (REFD) tiles hosted by Iowa Environmental Mesonet (IEM) — free, keyless.
+ *
+ * The browser loads tiles directly from RainViewer + IEM; we only return the
+ * manifest (host/paths + the HRRR init time and forecast-frame list).
+ *
+ * HRRR REFD is a MODEL SIMULATION, not observed radar — the page labels it as a
+ * forecast. Tiles: hrrr::REFD-F{fmin}-{YYYYMMDDHHmm}, 15-min steps to F1080 (+18h).
+ */
+
+const RAINVIEWER = "https://api.rainviewer.com/public/weather-maps.json";
+const IEM_TEMPLATE =
+  "https://mesonet.agron.iastate.edu/cache/tile.py/1.0.0/hrrr::REFD-F{fmin}-{init}/{z}/{x}/{y}.png";
+// Cheap availability probe (tiny z2 tile): 200 = that init is processed, 503 = not (yet).
+const IEM_PROBE =
+  "https://mesonet.agron.iastate.edu/cache/tile.py/1.0.0/hrrr::REFD-F0000-{init}/2/0/1.png";
+
+const pad = (n, w) => String(n).padStart(w, "0");
+
+// IEM model-init string in UTC: YYYYMMDDHHmm.
+export function iemInit(d) {
+  return (
+    `${d.getUTCFullYear()}${pad(d.getUTCMonth() + 1, 2)}${pad(d.getUTCDate(), 2)}` +
+    `${pad(d.getUTCHours(), 2)}${pad(d.getUTCMinutes(), 2)}`
+  );
+}
+
+// Freshest HRRR run that's reliably processed: the PREVIOUS top-of-hour (UTC).
+// HRRR runs hourly and a run is ready ~:50 past the hour, so the previous hour is
+// always safe. Costs ~1–2h of run age; negligible for a next-6h view. (Tunable.)
+export function hrrrInit(nowMs) {
+  const d = new Date(nowMs);
+  d.setUTCMinutes(0, 0, 0);
+  d.setUTCHours(d.getUTCHours() - 1);
+  return d;
+}
+
+// Forecast frames from now → now+hoursAhead at stepMin spacing, each within the
+// HRRR forecast range (F0000–F1080). { time:unixSec, fmin:"0090", kind:"fc" }.
+export function futureFrames(nowMs, init, opts = {}) {
+  const { hoursAhead = 6, stepMin = 30, maxFmin = 1080 } = opts;
+  const initMs = init.getTime();
+  const stepMs = stepMin * 60000;
+  const end = nowMs + hoursAhead * 3600000;
+  const frames = [];
+  for (let t = Math.ceil(nowMs / stepMs) * stepMs; t <= end; t += stepMs) {
+    const fmin = Math.round((t - initMs) / 60000);
+    if (fmin < 0 || fmin > maxFmin) continue;
+    frames.push({ time: Math.round(t / 1000), fmin: pad(fmin, 4), kind: "fc" });
+  }
+  return frames;
+}
+
+async function rainviewer() {
+  try {
+    const r = await fetch(RAINVIEWER, { signal: AbortSignal.timeout(4000) });
+    if (!r.ok) throw new Error(`rainviewer ${r.status}`);
+    const j = await r.json();
+    return { host: j.host, past: (j.radar && j.radar.past) || [], nowcast: (j.radar && j.radar.nowcast) || [] };
+  } catch {
+    return { host: null, past: [], nowcast: [] }; // soft-fail → forecast-only
+  }
+}
+
+async function iemHas(initStr) {
+  try {
+    const r = await fetch(IEM_PROBE.replace("{init}", initStr), { signal: AbortSignal.timeout(3500) });
+    return r.ok; // 200 = run available, 503 = not processed yet
+  } catch {
+    return false;
+  }
+}
+
+// Newest HRRR init IEM actually has processed. Starts at the previous top-of-hour and
+// steps back up to `tries` hours, skipping runs that 503 (unprocessed/lagging) — so the
+// page never asks for tiles that don't exist. Falls back to the oldest tried on total miss.
+export async function freshestInit(nowMs, tries = 4) {
+  const d = hrrrInit(nowMs);
+  for (let i = 0; i < tries; i++) {
+    if (await iemHas(iemInit(d))) return d;
+    d.setUTCHours(d.getUTCHours() - 1);
+  }
+  return d;
+}
+
+export async function getRadar(nowMs = Date.now()) {
+  const [observed, init] = await Promise.all([rainviewer(), freshestInit(nowMs)]);
+  return {
+    observed,
+    forecast: {
+      source: "HRRR (Iowa Environmental Mesonet)",
+      initUnix: Math.round(init.getTime() / 1000),
+      tileTemplate: IEM_TEMPLATE.replace("{init}", iemInit(init)),
+      frames: futureFrames(nowMs, init),
+    },
+    attribution: "Observed radar: RainViewer · Future radar: HRRR via Iowa Environmental Mesonet",
+  };
+}

--- a/ingest/src/read.js
+++ b/ingest/src/read.js
@@ -14,6 +14,7 @@ import { DynamoDBDocumentClient, QueryCommand } from "@aws-sdk/lib-dynamodb";
 import { getAlerts, getForecast } from "./nws.js";
 import { getCompare } from "./compare.js";
 import { getWater } from "./water.js";
+import { getRadar } from "./radar.js";
 
 const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 const TABLE = process.env.TABLE_NAME;
@@ -241,7 +242,17 @@ export const handler = async (event) => {
       }
     }
 
-    return res(404, { error: "not found", try: ["/api/current", "/api/history?hours=24", "/api/forecast", "/api/alerts", "/api/compare", "/api/water"] }, 15);
+    // Radar manifest: observed (RainViewer) + HRRR "future radar" frames (IEM). Keyless.
+    if (path.endsWith("/api/radar")) {
+      try {
+        return res(200, await getRadar(), 300);
+      } catch (e) {
+        console.error(JSON.stringify({ msg: "radar-upstream", error: String(e?.message || e) }));
+        return res(200, { observed: { host: null, past: [], nowcast: [] }, forecast: null, error: "upstream" }, 30);
+      }
+    }
+
+    return res(404, { error: "not found", try: ["/api/current", "/api/history?hours=24", "/api/forecast", "/api/alerts", "/api/compare", "/api/water", "/api/radar"] }, 15);
   } catch (e) {
     console.error(JSON.stringify({ msg: "read-error", error: String(e?.message || e), path }));
     return res(500, { error: "internal" }, 5);

--- a/ingest/test/radar.test.mjs
+++ b/ingest/test/radar.test.mjs
@@ -1,0 +1,40 @@
+// Unit tests for the pure HRRR helpers in ingest/src/radar.js. No network.
+// iemInit (UTC init string), hrrrInit (previous top-of-hour), futureFrames (now→+6h @30m).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { iemInit, hrrrInit, futureFrames } from "../src/radar.js";
+
+test("iemInit formats YYYYMMDDHHmm in UTC", () => {
+  assert.equal(iemInit(new Date(Date.UTC(2026, 7, 27, 15, 0, 0))), "202608271500"); // Aug = month 7
+  assert.equal(iemInit(new Date(Date.UTC(2026, 0, 3, 9, 5, 0))), "202601030905");
+});
+
+test("hrrrInit is the previous top-of-hour (UTC), reliably processed", () => {
+  const init = hrrrInit(Date.UTC(2026, 7, 27, 16, 20, 0));
+  assert.equal(iemInit(init), "202608271500");
+  // on the hour boundary it still steps back one hour
+  assert.equal(iemInit(hrrrInit(Date.UTC(2026, 7, 27, 16, 0, 0))), "202608271500");
+});
+
+test("futureFrames: 30-min steps from now→+6h, 4-digit fmin, ascending", () => {
+  const now = Date.UTC(2026, 7, 27, 16, 20, 0);
+  const init = hrrrInit(now); // 15:00Z
+  const frames = futureFrames(now, init);
+  assert.equal(frames.length, 12);              // 16:30 … 22:00 inclusive
+  assert.equal(frames[0].fmin, "0090");          // 16:30 − 15:00 = 90 min
+  assert.equal(frames[0].kind, "fc");
+  assert.equal(frames[frames.length - 1].fmin, "0420"); // 22:00 − 15:00 = 420 min
+  for (let i = 1; i < frames.length; i++) {
+    assert.ok(frames[i].time > frames[i - 1].time, "times strictly increasing");
+    assert.ok(Number(frames[i].fmin) <= 1080, "within HRRR forecast range");
+    assert.equal(frames[i].fmin.length, 4, "4-digit forecast minutes");
+  }
+});
+
+test("futureFrames: honors hoursAhead + stepMin", () => {
+  const now = Date.UTC(2026, 7, 27, 16, 0, 0);
+  const init = hrrrInit(now); // 15:00Z
+  const frames = futureFrames(now, init, { hoursAhead: 2, stepMin: 60 });
+  // 17:00 and 18:00 (16:00 itself is not > now-rounded start; ceil(16:00)→16:00, so 16:00,17:00,18:00)
+  assert.deepEqual(frames.map((f) => f.fmin), ["0060", "0120", "0180"]);
+});

--- a/web/radar.html
+++ b/web/radar.html
@@ -72,8 +72,18 @@
   /* controls */
   .rctrl{display:flex;align-items:center;gap:12px;background:var(--glass);border:1px solid var(--brd);border-radius:999px;padding:8px 14px;box-shadow:var(--shadow);backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);}
   .rplay{flex:none;width:38px;height:38px;border-radius:50%;border:1px solid var(--brd);background:var(--glass-2);color:var(--ink);font-size:1rem;cursor:pointer;display:flex;align-items:center;justify-content:center;}
-  .rslider{flex:1;accent-color:var(--teal);cursor:pointer;}
-  .rtime{flex:none;min-width:132px;text-align:right;font-weight:800;font-size:.86rem;font-variant-numeric:tabular-nums;}
+  .rslider-wrap{position:relative;flex:1;display:flex;align-items:center;}
+  /* Two-tone track: observed (teal) up to NOW, forecast (gold) after — split at --now. */
+  .rslider{-webkit-appearance:none;appearance:none;width:100%;height:7px;border-radius:999px;cursor:pointer;background:transparent;}
+  .rslider:focus{outline:none;}
+  .rslider::-webkit-slider-runnable-track{height:7px;border-radius:999px;background:linear-gradient(90deg,var(--teal) 0 var(--now,50%),var(--gold) var(--now,50%) 100%);}
+  .rslider::-moz-range-track{height:7px;border-radius:999px;background:linear-gradient(90deg,var(--teal) 0 var(--now,50%),var(--gold) var(--now,50%) 100%);}
+  .rslider::-webkit-slider-thumb{-webkit-appearance:none;appearance:none;width:15px;height:15px;margin-top:-4px;border-radius:50%;background:#fff;border:2px solid var(--teal-deep);box-shadow:0 1px 4px rgba(0,0,0,.45);}
+  .rslider::-moz-range-thumb{width:15px;height:15px;border:2px solid var(--teal-deep);border-radius:50%;background:#fff;box-shadow:0 1px 4px rgba(0,0,0,.45);}
+  /* "now" divider between observed (left) and forecast (right) frames */
+  .rnow{position:absolute;top:-3px;bottom:-3px;width:2px;background:var(--teal-deep);border-radius:2px;pointer-events:none;transform:translateX(-1px);box-shadow:0 0 6px rgba(127,230,226,.7);}
+  .rnow::after{content:"NOW";position:absolute;top:-15px;left:50%;transform:translateX(-50%);font-size:.55rem;font-weight:800;letter-spacing:.5px;color:var(--teal-deep);}
+  .rtime{text-align:center;font-weight:800;font-size:.9rem;font-variant-numeric:tabular-nums;color:var(--ink);}
   .rtime .tag{font-weight:700;font-size:.72rem;color:var(--ink-faint);}
   .rtime .tag.fc{color:var(--gold);} .rtime .tag.now{color:var(--teal-deep);}
   .rnote{font-size:.78rem;font-weight:600;color:var(--ink-faint);text-align:center;line-height:1.4;}
@@ -97,15 +107,16 @@
     <div id="map" aria-label="Live precipitation radar centered on Havasu Lake"></div>
     <div class="rctrl">
       <button class="rplay" id="rPlay" type="button" aria-label="Play/pause radar">&#9208;</button>
-      <input class="rslider" id="rSlider" type="range" min="0" max="0" value="0" step="1" aria-label="Radar frame" />
-      <span class="rtime" id="rTime">&mdash;</span>
+      <span class="rslider-wrap"><input class="rslider" id="rSlider" type="range" min="0" max="0" value="0" step="1" aria-label="Radar frame" /><span class="rnow" id="rNow" hidden></span></span>
     </div>
+    <div class="rtime" id="rTime">&mdash;</div>
     <div class="rlegend">
-      Light <span class="sw" style="background:#57b9ff"></span><span class="sw" style="background:#4be04b"></span><span class="sw" style="background:#f2f229"></span><span class="sw" style="background:#ff9e2b"></span><span class="sw" style="background:#ff4d4d"></span> Heavy
+      Light <span class="sw" style="background:#8ff08f"></span><span class="sw" style="background:#2fb62f"></span><span class="sw" style="background:#f2f229"></span><span class="sw" style="background:#ff9e2b"></span><span class="sw" style="background:#ff4d4d"></span> Heavy
     </div>
-    <div class="rnote" id="rNote">Animating the last ~2 hours of radar. A short-term forecast appears when rain is nearby.</div>
+    <div class="rnote" id="rNote">Past ~2 hours of observed radar, then the next 6 hours forecast. Future frames are an <b>HRRR model</b> simulation, not live radar.</div>
     <div class="foot">
-      Radar: <a href="https://www.rainviewer.com/" target="_blank" rel="noopener">RainViewer</a> &middot;
+      Observed radar: <a href="https://www.rainviewer.com/" target="_blank" rel="noopener">RainViewer</a> &middot;
+      future radar (HRRR): <a href="https://mesonet.agron.iastate.edu/" target="_blank" rel="noopener">Iowa Environmental Mesonet</a> &middot;
       map &copy; OpenStreetMap / CARTO &middot; community reference, not an official product.
       <a href="/water.html">Lake &amp; river &rarr;</a>
       <nav class="ftnav" aria-label="Site"><a href="/">Live conditions</a> &middot; <a href="/water.html">Lake Havasu water level</a> &middot; <a href="/radar.html">Radar</a></nav>
@@ -118,65 +129,94 @@
   var HAVASU=[34.4822,-114.4138];
   var $=function(id){return document.getElementById(id);};
   var map=L.map("map",{center:HAVASU,zoom:7,minZoom:4,maxZoom:9,zoomControl:true,attributionControl:true,worldCopyJump:true});
-  L.tileLayer("https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png",{
+  L.tileLayer("https://{s}.basemaps.cartocdn.com/rastertiles/dark_all/{z}/{x}/{y}{r}.png?key=cb1_2dzm_1_674318b44e9de52c84e5cab5",{
     subdomains:"abcd",maxZoom:19,
     attribution:'&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a> &middot; Radar <a href="https://www.rainviewer.com/">RainViewer</a>'
   }).addTo(map);
   L.circleMarker(HAVASU,{radius:6,color:"#ffd24a",weight:2,fillColor:"#ffd24a",fillOpacity:.9})
     .addTo(map).bindTooltip("Havasu Lake, CA",{direction:"top",offset:[0,-6]});
 
-  var RV_HOST="", frames=[], layers={}, pos=0, playing=false, timer=null, pastCount=0;
-  var SIZE=256, COLOR=4, SMOOTH=1, SNOW=1, OPACITY=0.72;
-  var playBtn=$("rPlay"), slider=$("rSlider"), timeEl=$("rTime");
+  var frames=[], layers={}, pos=0, playing=false, timer=null, boundary=0, shownKey=null;
+  var RV_HOST=null, FC_TEMPLATE=null;
+  var SIZE=256, COLOR=6, SMOOTH=1, SNOW=1, OPACITY=0.72; // RainViewer scheme 6 = NEXRAD L-III, matches HRRR's NWS ramp
+  var playBtn=$("rPlay"), slider=$("rSlider"), timeEl=$("rTime"), nowMark=$("rNow");
 
-  function tileUrl(path){ return RV_HOST+path+"/"+SIZE+"/{z}/{x}/{y}/"+COLOR+"/"+SMOOTH+"_"+SNOW+".png"; }
+  function fkey(f){ return f.kind+":"+(f.kind==="fc"?f.fmin:f.path); }
+  function tileUrl(f){
+    return f.kind==="fc"
+      ? FC_TEMPLATE.replace("{fmin}",f.fmin)                       // IEM HRRR simulated reflectivity
+      : RV_HOST+f.path+"/"+SIZE+"/{z}/{x}/{y}/"+COLOR+"/"+SMOOTH+"_"+SNOW+".png"; // RainViewer observed
+  }
   function ensureLayer(f){
-    if(!layers[f.path]) layers[f.path]=L.tileLayer(tileUrl(f.path),{tileSize:SIZE,opacity:0,maxNativeZoom:7,zIndex:100});
-    if(!map.hasLayer(layers[f.path])) layers[f.path].addTo(map);
-    return layers[f.path];
+    var k=fkey(f);
+    if(!layers[k]) layers[k]=L.tileLayer(tileUrl(f),{tileSize:256,opacity:0,maxNativeZoom:7,zIndex:100});
+    if(!map.hasLayer(layers[k])){
+      layers[k].addTo(map);
+      var c=layers[k].getContainer&&layers[k].getContainer();
+      if(c) c.style.transition="opacity .4s ease"; // cross-fade between frames/providers
+    }
+    return layers[k];
   }
   function label(f){
     var mins=Math.round((f.time*1000-Date.now())/60000);
     var t=new Date(f.time*1000).toLocaleTimeString("en-US",{timeZone:"America/Los_Angeles",hour:"numeric",minute:"2-digit"});
-    var tag = mins<=-1 ? '<span class="tag">'+Math.abs(mins)+" min ago</span>"
-      : mins>=1 ? '<span class="tag fc">+'+mins+" min · forecast</span>"
-      : '<span class="tag now">now</span>';
+    var tag;
+    if(mins<=-1){ tag='<span class="tag">'+Math.abs(mins)+" min ago</span>"; }
+    else if(mins>=1){
+      var lbl = mins>=60 ? ("+"+(Math.round(mins/60*10)/10)+"h") : ("+"+mins+" min");
+      tag='<span class="tag fc">'+lbl+" · forecast"+(f.kind==="fc"?" (model)":"")+"</span>";
+    } else { tag='<span class="tag now">now</span>'; }
     timeEl.innerHTML=t+" "+tag;
   }
   function show(i){
     if(!frames.length)return;
-    var prev=frames[pos];
     pos=(i%frames.length+frames.length)%frames.length;
-    var cur=frames[pos];
-    ensureLayer(cur);
-    ensureLayer(frames[(pos+1)%frames.length]); // preload next
-    if(prev&&layers[prev.path]&&prev.path!==cur.path) layers[prev.path].setOpacity(0);
-    layers[cur.path].setOpacity(OPACITY);
+    var cur=frames[pos], nxt=frames[(pos+1)%frames.length], ck=fkey(cur), nk=fkey(nxt);
+    ensureLayer(cur); ensureLayer(nxt); // current (shown) + next (preloaded)
+    // Throttle to a tiny window — current, next, and the outgoing frame — so IEM HRRR (renders
+    // on-demand, 503s under a full-frame burst) only ever sees a trickle. The outgoing layer
+    // lingers one beat so the CSS opacity transition cross-fades instead of hard-cutting.
+    var keep=[ck,nk]; if(shownKey) keep.push(shownKey);
+    Object.keys(layers).forEach(function(k){ if(keep.indexOf(k)<0 && map.hasLayer(layers[k])) map.removeLayer(layers[k]); });
+    if(shownKey && shownKey!==ck && layers[shownKey]) layers[shownKey].setOpacity(0); // fade previous out
+    layers[nk].setOpacity(0);
+    layers[ck].setOpacity(OPACITY);                                                    // fade current in
+    shownKey=ck;
     slider.value=pos; label(cur);
   }
-  function play(){ playing=true; playBtn.innerHTML="&#9208;"; clearInterval(timer);
-    timer=setInterval(function(){ var next=pos+1; show(next); if(next>=frames.length){/*loop*/} }, next_delay()); }
-  function next_delay(){ return (pos===frames.length-1)?1100:520; } // linger on the newest frame
-  function pause(){ playing=false; playBtn.innerHTML="&#9654;"; clearInterval(timer); }
+  function next_delay(){ return pos===frames.length-1?1100:(pos===boundary-1?900:520); } // linger at +6h end and at "now"
+  function step(){ show(pos+1); if(playing) timer=setTimeout(step,next_delay()); }
+  function play(){ playing=true; playBtn.innerHTML="&#9208;"; clearTimeout(timer); timer=setTimeout(step,next_delay()); }
+  function pause(){ playing=false; playBtn.innerHTML="&#9654;"; clearTimeout(timer); }
 
   playBtn.addEventListener("click",function(){ playing?pause():play(); });
   slider.addEventListener("input",function(){ pause(); show(+slider.value); });
 
-  fetch("https://api.rainviewer.com/public/weather-maps.json",{cache:"no-store"})
+  function placeNow(){
+    var pct = frames.length>1 ? (boundary/(frames.length-1)*100) : 0;
+    slider.style.setProperty("--now", pct+"%"); // colors the track: teal (past) | gold (future)
+    if(frames.length<2||boundary<=0||boundary>frames.length-1){ nowMark.hidden=true; return; }
+    nowMark.hidden=false; nowMark.style.left=pct+"%";
+  }
+
+  fetch("/api/radar",{cache:"no-store"})
     .then(function(r){return r.json();})
     .then(function(j){
-      RV_HOST=j.host;
-      var past=(j.radar&&j.radar.past)||[], now=(j.radar&&j.radar.nowcast)||[];
-      frames=past.concat(now); pastCount=past.length;
-      if(!frames.length){ $("rNote").textContent="No radar data available right now."; return; }
+      var obs=j.observed||{}, fc=j.forecast||null;
+      RV_HOST=obs.host; if(fc) FC_TEMPLATE=fc.tileTemplate;
+      var obsFrames=(RV_HOST?(obs.past||[]).concat(obs.nowcast||[]):[]).map(function(f){ return {time:f.time,kind:"obs",path:f.path}; });
+      var fcFrames=(fc&&fc.frames?fc.frames:[]).map(function(f){ return {time:f.time,kind:"fc",fmin:f.fmin}; });
+      frames=obsFrames.concat(fcFrames);
+      if(!frames.length){ $("rNote").textContent="Radar is temporarily unavailable — try again shortly."; return; }
+      var nowMs=Date.now();
+      boundary=frames.filter(function(f){ return f.time*1000<=nowMs; }).length; // index of the first future frame
       slider.max=frames.length-1;
-      pos=Math.max(0,past.length-1); // start on "now"
-      show(pos);
-      play();
-      if(now.length) $("rNote").textContent="Animating the last ~2 hours of radar, plus a short-term forecast (dashed future frames).";
+      pos=Math.max(0,boundary-1); // start on "now"
+      placeNow(); show(pos); play();
     })
     .catch(function(){ $("rNote").textContent="Radar is temporarily unavailable — try again shortly."; });
 
+  window.addEventListener("resize",placeNow);
   // Pause the loop when the tab is hidden (save data/battery).
   document.addEventListener("visibilitychange",function(){ if(document.hidden)pause(); });
 })();

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,6 +1,6 @@
 /* Havasu Lake Weather — service worker (installability + offline shell) */
-const CACHE = "havasu-wx-v38";  // bump on EVERY web/ change (cache correctness; CI-enforced)
-const RELEASE = "r2";           // bump ONLY for user-facing changes — drives the "update available" toast
+const CACHE = "havasu-wx-v39";  // bump on EVERY web/ change (cache correctness; CI-enforced)
+const RELEASE = "r3";           // bump ONLY for user-facing changes — drives the "update available" toast
 const SHELL = [
   "/", "/index.html", "/water.html", "/radar.html", "/manifest.json", "/sw-register.js",
   "/assets/icon-192.png", "/assets/icon-512.png", "/assets/icon-180.png",


### PR DESCRIPTION
Closes #82.

Extends `/radar` from past-2h observed radar into a **next-6h "future radar"** using **HRRR simulated reflectivity** (REFD) tiles from Iowa Environmental Mesonet — free, keyless data. Built and previewed locally against real data.

## What's in it
- **`/api/radar` proxy** (`radar.js` + `read.js`): RainViewer manifest passthrough + HRRR forecast frames (now→+6h, 30-min steps). The proxy **verifies the HRRR init is processed** (steps back an hour on a 503) so the page never requests tiles that don't exist.
- **`radar.html`:** observed (RainViewer) + forecast (IEM HRRR) layers; **NOW divider** on its own row; **two-tone scrubber** (teal past / gold forecast) split at NOW; gold "+Nh · forecast (model)" labels; **cross-fade** between frames/providers; **throttled** to current+next layer (IEM renders on-demand and 503s under a full-frame burst); RainViewer on **NEXRAD** color scheme to match HRRR's NWS ramp; honesty note that future = model, not observed.
- **CARTO basemap fix (folded in):** CARTO began gating their free raster basemap, so `/radar` was showing "API KEY REQUIRED" watermarks **live**. Swapped to the authenticated `rastertiles/dark_all` endpoint with a **public, domain-restricted client key** (not a server secret). ⚠️ Restrict the key to `havasulakeweather.com` in the CARTO dashboard.
- **SW** `v39` / `RELEASE r3`; **tests** `ingest/test/radar.test.mjs`; `npm test` **61/61**.

## Notes
- HRRR is a model forecast (not observed radar) — labeled as such; skillful ~0–6h, hence the +6h cap.
- Residual observed-vs-forecast look differences (cyan vs lavender light echoes, ~1km radar vs ~3km model) are inherent and left as a subtle real/forecast cue.
- Future: CARTO is retiring raster for vector (MapLibre) — its own ticket later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHfTY9b4p18XoeNJPactfL