### PR TITLE
HLW-046: water ingest resilience — carry-forward last-good + USGS retry

### DIFF
--- a/docs/issues/HLW-046-water-carry-forward.md
+++ b/docs/issues/HLW-046-water-carry-forward.md
@@ -1,0 +1,44 @@
+# HLW-046: water ingest resilience — carry-forward last-good, retry USGS
+
+- **Status:** in-progress — built + verified locally 2026-09-01; ready for PR. Deploy gated on Chad's merge.
+- **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/85
+- **Branch:** `fix/HLW-046-water-carry-forward`
+- **PR:** _(opens after build)_
+- **Created:** 2026-09-01
+
+## Summary
+
+A single slow USGS response blanks the lake level for up to 6 hours. Make the scheduled
+water-ingest resilient: **carry forward the last-good value** instead of overwriting a good
+snapshot with `null`, and give the USGS fetch **one retry + a bit more timeout** so a merely
+slow response doesn't fail at all.
+
+## Root cause (diagnosed)
+
+`2026-08-31 14:42` the ingest ran **10.3s** (vs ~6s) and logged `havasuElevFt: null`. USGS
+answered too slowly and exceeded the 8s fetch timeout; the ingest wrote
+`havasuElevFt: lake.elevationFt ?? null` → a **null clobbered the good snapshot**. `/api/water`
+served the blank lake until the next good run (20:42) overwrote it. Not rate-limiting — our
+cadence is a gentle `rate(6 hours)`; USGS was just briefly slow, and the ingest was fragile.
+
+## Plan
+
+- [x] **`water-ingest.js` carry-forward:** reads the latest `WATER#DAILY` snapshot; for each
+      data field uses `fresh ?? previous ?? null`. Pure exported `carryForward(fresh, prev)` →
+      `{ merged, carried }`, logs the carried keys. Kept the "skip all-null" guard.
+- [x] **`water.js usgsLatest`:** one retry with 500ms backoff; per-attempt timeout 8s (Lambda
+      timeout 30s, USGS calls run in parallel → ≤ ~16s worst case).
+- [x] **Test:** `ingest/test/water-ingest.test.mjs` (fresh wins; null → prev; both null → null;
+      no prev; the 08-31 shape). `npm test` **66/66** green.
+- [x] **Verified locally (read-only dry run vs real DynamoDB):** prev=2026-09-01 elev 451.13;
+      normal run → fresh 451.31, nothing carried; simulated USGS blip → elev/storage/mohave
+      carried forward (not null), fresh RISE still wins. Exactly the 08-31 failure, fixed.
+- [ ] PR → Chad merges (deploy). Post-deploy: manual ingest run stores a full snapshot; `/api/water` lake stays populated.
+
+## Notes
+
+- Carrying a value forward slightly under-states that field's freshness (the snapshot date reads
+  "today"), but lake level moves inches/day — a stale-but-valid level beats a blank one, and the
+  existing schema already stores bare numbers without per-field observedAt.
+- Nothing is broken right now (self-healed 2026-08-31 20:42); this is preventative for the next
+  USGS hiccup.

--- a/ingest/src/water-ingest.js
+++ b/ingest/src/water-ingest.js
@@ -6,14 +6,57 @@
  * (pk = WATER#DAILY, sk = <YYYY-MM-DD>). /api/water then reads from these snapshots
  * instead of hitting USGS/RISE on the hot path — fast, reliable, and it accumulates
  * our own history. Idempotent per day (each run upserts today's snapshot).
+ *
+ * Resilience (HLW-046): a source (esp. slow USGS) can hiccup and return null for one
+ * run. Rather than overwrite a good snapshot with null — which blanked the lake for up
+ * to 6h — we carry forward the previous snapshot's value for any field that comes back
+ * null. Worst case a field is a few hours stale; it never goes blank from a transient blip.
  */
 
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
-import { DynamoDBDocumentClient, PutCommand } from "@aws-sdk/lib-dynamodb";
+import { DynamoDBDocumentClient, PutCommand, QueryCommand } from "@aws-sdk/lib-dynamodb";
 import { getLive } from "./water.js";
 
 const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}), { marshallOptions: { removeUndefinedValues: true } });
 const TABLE = process.env.TABLE_NAME;
+
+// Data fields carried forward from the last snapshot when a source returns null.
+const CARRY = [
+  "havasuElevFt", "havasuStorageAf", "havasuTempF",
+  "mohaveElevFt", "mohaveStorageAf", "mohaveTempF",
+  "davisCfs", "parkerCfs",
+  "powellElevFt", "powellStorageAf", "powellInflowCfs",
+  "canyonCfs", "canyonTempF", "meadElevFt", "meadStorageAf", "hooverCfs",
+];
+
+// Pure: prefer the fresh value; when it's null, fall back to the previous snapshot's value
+// (never overwrite good → null). Returns the merged fields + which keys were carried forward.
+export function carryForward(fresh, prev) {
+  const merged = { ...fresh };
+  const carried = [];
+  if (prev) {
+    for (const k of CARRY) {
+      if (merged[k] == null && prev[k] != null) { merged[k] = prev[k]; carried.push(k); }
+    }
+  }
+  return { merged, carried };
+}
+
+// Newest stored WATER#DAILY snapshot (for carry-forward); null if none / on error.
+async function latestSnapshot() {
+  try {
+    const r = await ddb.send(new QueryCommand({
+      TableName: TABLE,
+      KeyConditionExpression: "pk = :pk",
+      ExpressionAttributeValues: { ":pk": "WATER#DAILY" },
+      ScanIndexForward: false,
+      Limit: 1,
+    }));
+    return r.Items?.[0] || null;
+  } catch {
+    return null;
+  }
+}
 
 export const handler = async () => {
   const w = await getLive();
@@ -21,11 +64,7 @@ export const handler = async () => {
   const c = Object.fromEntries((w.cascade || []).map((n) => [n.key, n])); // upstream cascade by key
   const date = new Date().toISOString().slice(0, 10); // UTC day; upsert keeps one/day
 
-  const item = {
-    pk: "WATER#DAILY",
-    sk: date,
-    date,
-    updatedAt: new Date().toISOString(),
+  const fresh = {
     havasuElevFt: lake.elevationFt ?? null,
     havasuStorageAf: lake.storageAf ?? null,
     havasuTempF: lake.waterTempF ?? null,
@@ -45,7 +84,11 @@ export const handler = async () => {
     hooverCfs: c.hoover ? c.hoover.cfs : null,
   };
 
-  // Skip writing an all-null snapshot (e.g. every upstream source hiccupped).
+  // Carry forward any field that hiccupped to null, from the last snapshot.
+  const { merged, carried } = carryForward(fresh, await latestSnapshot());
+  const item = { pk: "WATER#DAILY", sk: date, date, updatedAt: new Date().toISOString(), ...merged };
+
+  // Skip writing an all-null snapshot (every source hiccupped AND nothing to carry forward).
   const anyValue = [item.havasuElevFt, item.davisCfs, item.parkerCfs, item.havasuStorageAf].some((v) => v != null);
   if (!anyValue) {
     console.error(JSON.stringify({ msg: "water-ingest-empty", date }));
@@ -53,6 +96,10 @@ export const handler = async () => {
   }
 
   await ddb.send(new PutCommand({ TableName: TABLE, Item: item }));
-  console.log(JSON.stringify({ msg: "water-stored", date, davisCfs: item.davisCfs, parkerCfs: item.parkerCfs, havasuStorageAf: item.havasuStorageAf, havasuElevFt: item.havasuElevFt }));
-  return { stored: date };
+  console.log(JSON.stringify({
+    msg: "water-stored", date, davisCfs: item.davisCfs, parkerCfs: item.parkerCfs,
+    havasuStorageAf: item.havasuStorageAf, havasuElevFt: item.havasuElevFt,
+    carried: carried.length ? carried : undefined,
+  }));
+  return { stored: date, carried };
 };

--- a/ingest/src/water.js
+++ b/ingest/src/water.js
@@ -62,23 +62,32 @@ const POOL = {
 
 const now = () => new Date().toISOString();
 
-async function usgsLatest(service, site, pcode, timeoutMs = 4500) {
+async function usgsLatest(service, site, pcode, timeoutMs = 8000, tries = 2) {
   const url = `https://waterservices.usgs.gov/nwis/${service}/?format=json&sites=${site}&parameterCd=${pcode}&siteStatus=all`;
-  const ctrl = new AbortController();
-  const t = setTimeout(() => ctrl.abort(), timeoutMs);
-  try {
-    const r = await fetch(url, { headers: { "user-agent": UA }, signal: ctrl.signal });
-    if (!r.ok) throw new Error(`USGS ${service} ${site} -> ${r.status}`);
-    const j = await r.json();
-    const ts = (j.value && j.value.timeSeries) || [];
-    if (!ts.length) return null;
-    const vals = ts[0].values[0].value;
-    const last = vals && vals.length ? vals[vals.length - 1] : null;
-    if (!last || last.value == null) return null;
-    return { value: parseFloat(last.value), at: last.dateTime };
-  } finally {
-    clearTimeout(t);
+  let lastErr;
+  // Retry a slow/erroring USGS once (Lambda timeout is 30s; the 3 USGS calls run in parallel,
+  // so worst case ~2×8s). A legit empty response returns null immediately — only failures retry.
+  for (let attempt = 1; attempt <= tries; attempt++) {
+    const ctrl = new AbortController();
+    const t = setTimeout(() => ctrl.abort(), timeoutMs);
+    try {
+      const r = await fetch(url, { headers: { "user-agent": UA }, signal: ctrl.signal });
+      if (!r.ok) throw new Error(`USGS ${service} ${site} -> ${r.status}`);
+      const j = await r.json();
+      const ts = (j.value && j.value.timeSeries) || [];
+      if (!ts.length) return null;
+      const vals = ts[0].values[0].value;
+      const last = vals && vals.length ? vals[vals.length - 1] : null;
+      if (!last || last.value == null) return null;
+      return { value: parseFloat(last.value), at: last.dateTime };
+    } catch (e) {
+      lastErr = e;
+      if (attempt < tries) await new Promise((res) => setTimeout(res, 500)); // brief backoff, then one retry
+    } finally {
+      clearTimeout(t);
+    }
   }
+  throw lastErr;
 }
 
 // USBR RISE — latest daily value for a catalog item. RISE requires the JSON:API media

--- a/ingest/test/water-ingest.test.mjs
+++ b/ingest/test/water-ingest.test.mjs
@@ -1,0 +1,53 @@
+// Unit tests for carryForward(fresh, prev) from ingest/src/water-ingest.js (HLW-046).
+// Pure merge, no AWS/network: a null field falls back to the previous snapshot so a
+// transient source hiccup never blanks a good value.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { carryForward } from "../src/water-ingest.js";
+
+test("fresh value wins over previous", () => {
+  const { merged, carried } = carryForward(
+    { havasuElevFt: 451.2, davisCfs: 5000 },
+    { havasuElevFt: 450.0, davisCfs: 4000 },
+  );
+  assert.equal(merged.havasuElevFt, 451.2);
+  assert.equal(merged.davisCfs, 5000);
+  assert.deepEqual(carried, []);
+});
+
+test("null fresh falls back to previous (never blanks a good value)", () => {
+  const { merged, carried } = carryForward(
+    { havasuElevFt: null, havasuStorageAf: null, davisCfs: 5409 },
+    { havasuElevFt: 451.4, havasuStorageAf: 527971, davisCfs: 5000 },
+  );
+  assert.equal(merged.havasuElevFt, 451.4);     // carried
+  assert.equal(merged.havasuStorageAf, 527971); // carried
+  assert.equal(merged.davisCfs, 5409);          // fresh wins
+  assert.ok(carried.includes("havasuElevFt"));
+  assert.ok(carried.includes("havasuStorageAf"));
+  assert.ok(!carried.includes("davisCfs"));
+});
+
+test("both null stays null (nothing to carry)", () => {
+  const { merged, carried } = carryForward({ havasuElevFt: null }, { havasuElevFt: null });
+  assert.equal(merged.havasuElevFt, null);
+  assert.deepEqual(carried, []);
+});
+
+test("no previous snapshot leaves fresh untouched", () => {
+  const { merged, carried } = carryForward({ havasuElevFt: null, davisCfs: 5409 }, null);
+  assert.equal(merged.havasuElevFt, null);
+  assert.equal(merged.davisCfs, 5409);
+  assert.deepEqual(carried, []);
+});
+
+test("only the 08-31 failure shape: USGS fields carried, RISE fields fresh", () => {
+  const fresh = { havasuElevFt: null, havasuStorageAf: null, mohaveElevFt: null, davisCfs: 5409, parkerCfs: 2989 };
+  const prev = { havasuElevFt: 451.71, havasuStorageAf: 532373, mohaveElevFt: 643, davisCfs: 5389, parkerCfs: 1934 };
+  const { merged, carried } = carryForward(fresh, prev);
+  assert.equal(merged.havasuElevFt, 451.71);
+  assert.equal(merged.mohaveElevFt, 643);
+  assert.equal(merged.davisCfs, 5409);   // fresh RISE wins
+  assert.equal(merged.parkerCfs, 2989);
+  assert.deepEqual(carried.sort(), ["havasuElevFt", "havasuStorageAf", "mohaveElevFt"]);
+});


### PR DESCRIPTION
Closes #85.

Fixes the root cause of the 2026-08-31 lake-level outage: a slow USGS response (>8s) made the scheduled ingest store `havasuElevFt: null`, **overwriting the good snapshot**, and `/api/water` served the blank lake for ~6h until the next good run.

## Changes
- **`water-ingest.js` — carry-forward last-good.** Reads the latest `WATER#DAILY` snapshot; for any field that comes back null, keeps the previous value instead of overwriting with null (pure, tested `carryForward(fresh, prev)` → `{ merged, carried }`; logs which keys were carried). A transient source blip can no longer blank a good value. Kept the skip-all-null guard.
- **`water.js usgsLatest` — one retry** with 500ms backoff (per-attempt 8s; Lambda timeout is 30s, USGS calls run in parallel → ≤ ~16s worst case) so a merely-slow response doesn't fail.

## Verification
- `ingest/test/water-ingest.test.mjs` — `npm test` **66/66**.
- **Read-only dry run vs real DynamoDB:** prev=2026-09-01 elev 451.13; normal run → fresh 451.31 (nothing carried); a simulated USGS blip (the 08-31 shape) → elev/storage/mohave **carried forward** (not null) while fresh RISE (davis) still wins.
- (Also happened to catch a *live* USGS blip mid-build — confirms these are real and worth defending against.)

## Notes
- Carried values slightly under-state that field's freshness (snapshot date reads "today"), but lake level moves inches/day — a stale-but-valid level beats a blank one.
- Ingest-only change; the site job will be skipped on merge, ingest job redeploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHfTY9b4p18XoeNJPactfL