### PR TITLE
HLW-047: Air Quality panel (Open-Meteo US AQI + pollutant help balloons)

### DIFF
--- a/docs/issues/HLW-047-air-quality.md
+++ b/docs/issues/HLW-047-air-quality.md
@@ -1,0 +1,56 @@
+# HLW-047: Air Quality tile (Open-Meteo US AQI + next-24h peak)
+
+- **Status:** in-progress — built + previewed locally 2026-09-01; shipping. Deploy = Chad's merge.
+- **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/88
+- **Branch:** `feat/HLW-047-air-quality`
+- **PR:** _(opens after local preview)_
+- **Created:** 2026-09-01
+
+## Summary
+
+Add an **Air Quality** stat tile to the home page — current **US AQI** (color-coded category +
+dominant pollutant) plus a **next-24h peak** heads-up — backed by a new keyless `/api/air`
+(Open-Meteo Air Quality / CAMS). No dedicated page: AQI is a single headline number + category +
+one pollutant + a short forecast, which is tile-sized (a page like /water or /radar earns its keep
+with history charts / cascade / map; AQI has no such depth).
+
+## Motivation / context
+
+Desert-SW summer/fall = wildfire smoke + blowing dust. A lake community planning boating/outdoor
+time benefits from an at-a-glance "is the air OK / smoky today" with a short look-ahead. AQI is
+naturally color-coded (Good→Hazardous), so it mirrors the existing UV tile.
+
+## Source (decided)
+
+**Open-Meteo Air Quality only** — free, keyless, CAMS-modeled at the lake's exact lat/lon (beats
+AirNow's nearest-monitor, which is miles off across the river for this remote spot). Confirmed live:
+US AQI 55 (Moderate), PM2.5-driven; per-pollutant `us_aqi_*` sub-indices returned (for the dominant
+pollutant); hourly forecast to 7 days. Attribution: **CAMS + Open-Meteo**.
+
+## Plan
+
+- [x] **`ingest/src/air.js` + `/api/air`** (read Lambda): current `us_aqi` + `us_aqi_*` sub-indices
+      + `pm2_5/pm10/ozone/dust` concentrations + hourly `us_aqi`. Returns `{ aqi, category,
+      categorySlug, dominant, pollutants:{pm25,pm10,ozone,dust}, peak:{aqi,category,at}, source }`.
+      Pure helpers `aqiCategory` / `dominant` (argmax sub-index) / `peakNext24`. Cache 1h; soft-fail.
+- [x] **`web/index.html`:** **full-width panel** (`grid-column:1/-1`, no dangling 5th slot) — AQI
+      number + color-coded category chip + **pollutant breakdown** (PM2.5/PM10/Ozone/Dust µg/m³) +
+      "PM2.5 driving · modeled (CAMS)" + conditional "↑ NN by \<time\>" next-24h peak. Each pollutant
+      is a button that opens a **help balloon** (plain-language explainer + scale; Esc/tap-away closes;
+      `.tiles` lifted to `z-index:20` so the balloon isn't clipped by the panel below). SW → `v40`/`r4`.
+- [x] **Test:** `ingest/test/air.test.mjs` (aqiCategory / dominant / peakNext24). `npm test` **71/71**.
+- [x] Local preview verified (tile, breakdown one-row at 390px, balloons over adjacent panels) → PR → Chad merges (deploy).
+
+## Acceptance criteria
+
+- [x] Home page shows a color-coded AQI panel with the pollutant breakdown, per-pollutant help
+      balloons, dominant pollutant, and a (conditional) next-24h peak.
+- [x] Keyless (no new secrets); `npm test` 71/71; SW cache + release bumped (`v40`/`r4`).
+
+## Notes
+
+- US AQI categories: 0–50 Good, 51–100 Moderate, 101–150 Unhealthy for Sensitive Groups,
+  151–200 Unhealthy, 201–300 Very Unhealthy, 301+ Hazardous.
+- `dominant` = the pollutant whose `us_aqi_*` sub-index equals the overall `us_aqi` (the max).
+- Modeled (CAMS), not an EPA monitor — label the source honestly. AirNow (official, keyed) is a
+  possible later cross-check, out of scope here.

--- a/ingest/src/air.js
+++ b/ingest/src/air.js
@@ -1,0 +1,87 @@
+/**
+ * Havasu Lake Weather — air quality (HLW-047).
+ *
+ * Open-Meteo Air Quality (CAMS) — free + keyless. Current US AQI, the dominant
+ * pollutant, and the next-24h peak, for the home-page tile. Modeled at the lake's
+ * coordinates (not an EPA monitor) — labeled as such. Attribution: CAMS + Open-Meteo.
+ */
+
+const HAVASU = { lat: 34.4822, lon: -114.4138 };
+const BASE = "https://air-quality-api.open-meteo.com/v1/air-quality";
+
+// US AQI category by index value: [maxInclusive, name, slug].
+const CATS = [
+  [50, "Good", "good"],
+  [100, "Moderate", "moderate"],
+  [150, "Unhealthy for Sensitive Groups", "usg"],
+  [200, "Unhealthy", "unhealthy"],
+  [300, "Very Unhealthy", "veryunhealthy"],
+  [Infinity, "Hazardous", "hazardous"],
+];
+export function aqiCategory(aqi) {
+  if (aqi == null || !Number.isFinite(aqi)) return null;
+  for (const [hi, name, slug] of CATS) if (aqi <= hi) return { name, slug };
+  return { name: "Hazardous", slug: "hazardous" };
+}
+
+// Friendly labels for the per-pollutant US AQI sub-index fields.
+const POLL = {
+  us_aqi_pm2_5: "PM2.5", us_aqi_pm10: "PM10", us_aqi_ozone: "Ozone",
+  us_aqi_nitrogen_dioxide: "NO₂", us_aqi_sulphur_dioxide: "SO₂", us_aqi_carbon_monoxide: "CO",
+};
+// Dominant pollutant = the sub-index that's highest (it drives the overall AQI).
+export function dominant(cur) {
+  let best = null, bestv = -1;
+  for (const k of Object.keys(POLL)) {
+    const v = cur?.[k];
+    if (typeof v === "number" && v > bestv) { bestv = v; best = k; }
+  }
+  return best ? POLL[best] : null;
+}
+
+// Highest US AQI in the next 24h from the hourly series (unixtime seconds).
+export function peakNext24(times, values, nowMs = Date.now()) {
+  if (!Array.isArray(times) || !Array.isArray(values)) return null;
+  const nowS = Math.floor(nowMs / 1000), end = nowS + 24 * 3600;
+  let peak = null;
+  for (let i = 0; i < times.length; i++) {
+    const t = times[i], v = values[i];
+    if (typeof t !== "number" || typeof v !== "number") continue;
+    if (t < nowS || t > end) continue;
+    if (!peak || v > peak.aqi) peak = { aqi: Math.round(v), at: t };
+  }
+  return peak;
+}
+
+export async function getAir(nowMs = Date.now()) {
+  const params = new URLSearchParams({
+    latitude: String(HAVASU.lat), longitude: String(HAVASU.lon),
+    current: "us_aqi,us_aqi_pm2_5,us_aqi_pm10,us_aqi_ozone,us_aqi_nitrogen_dioxide,pm2_5,pm10,ozone,dust",
+    hourly: "us_aqi",
+    timeformat: "unixtime",
+    forecast_days: "2",
+  });
+  const r = await fetch(`${BASE}?${params}`, { signal: AbortSignal.timeout(5000) });
+  if (!r.ok) throw new Error(`open-meteo air ${r.status}`);
+  const j = await r.json();
+  const cur = j.current || {};
+  const aqi = Number.isFinite(cur.us_aqi) ? Math.round(cur.us_aqi) : null;
+  const cat = aqiCategory(aqi);
+  const peak = peakNext24(j.hourly?.time, j.hourly?.us_aqi, nowMs);
+  return {
+    source: "Open-Meteo (CAMS)",
+    observedAt: cur.time ?? null, // unix seconds
+    aqi,
+    category: cat?.name ?? null,
+    categorySlug: cat?.slug ?? null,
+    dominant: dominant(cur),
+    // Current concentrations (µg/m³) for the breakdown row.
+    pollutants: {
+      pm25: Number.isFinite(cur.pm2_5) ? +cur.pm2_5.toFixed(1) : null,
+      pm10: Number.isFinite(cur.pm10) ? Math.round(cur.pm10) : null,
+      ozone: Number.isFinite(cur.ozone) ? Math.round(cur.ozone) : null,
+      dust: Number.isFinite(cur.dust) ? Math.round(cur.dust) : null,
+    },
+    peak: peak ? { aqi: peak.aqi, at: peak.at, category: aqiCategory(peak.aqi)?.name ?? null } : null,
+  };
+}

--- a/ingest/src/read.js
+++ b/ingest/src/read.js
@@ -15,6 +15,7 @@ import { getAlerts, getForecast } from "./nws.js";
 import { getCompare } from "./compare.js";
 import { getWater } from "./water.js";
 import { getRadar } from "./radar.js";
+import { getAir } from "./air.js";
 
 const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 const TABLE = process.env.TABLE_NAME;
@@ -252,7 +253,17 @@ export const handler = async (event) => {
       }
     }
 
-    return res(404, { error: "not found", try: ["/api/current", "/api/history?hours=24", "/api/forecast", "/api/alerts", "/api/compare", "/api/water", "/api/radar"] }, 15);
+    // Air quality: Open-Meteo (CAMS) US AQI + dominant pollutant + next-24h peak. Keyless.
+    if (path.endsWith("/api/air")) {
+      try {
+        return res(200, await getAir(), 3600); // AQI updates hourly
+      } catch (e) {
+        console.error(JSON.stringify({ msg: "air-upstream", error: String(e?.message || e) }));
+        return res(200, { source: "Open-Meteo (CAMS)", aqi: null, category: null, dominant: null, peak: null, error: "upstream" }, 60);
+      }
+    }
+
+    return res(404, { error: "not found", try: ["/api/current", "/api/history?hours=24", "/api/forecast", "/api/alerts", "/api/compare", "/api/water", "/api/radar", "/api/air"] }, 15);
   } catch (e) {
     console.error(JSON.stringify({ msg: "read-error", error: String(e?.message || e), path }));
     return res(500, { error: "internal" }, 5);

--- a/ingest/test/air.test.mjs
+++ b/ingest/test/air.test.mjs
@@ -1,0 +1,44 @@
+// Unit tests for the pure air-quality helpers in ingest/src/air.js (HLW-047). No network.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { aqiCategory, dominant, peakNext24 } from "../src/air.js";
+
+test("aqiCategory: US AQI breakpoints", () => {
+  assert.equal(aqiCategory(0).slug, "good");
+  assert.equal(aqiCategory(50).slug, "good");
+  assert.equal(aqiCategory(51).slug, "moderate");
+  assert.equal(aqiCategory(100).slug, "moderate");
+  assert.equal(aqiCategory(101).slug, "usg");
+  assert.equal(aqiCategory(150).name, "Unhealthy for Sensitive Groups");
+  assert.equal(aqiCategory(175).slug, "unhealthy");
+  assert.equal(aqiCategory(250).slug, "veryunhealthy");
+  assert.equal(aqiCategory(400).slug, "hazardous");
+});
+
+test("aqiCategory: null / non-finite -> null", () => {
+  assert.equal(aqiCategory(null), null);
+  assert.equal(aqiCategory(undefined), null);
+  assert.equal(aqiCategory(NaN), null);
+});
+
+test("dominant: friendly name of the highest sub-index", () => {
+  assert.equal(dominant({ us_aqi_pm2_5: 55, us_aqi_pm10: 30, us_aqi_ozone: 37 }), "PM2.5");
+  assert.equal(dominant({ us_aqi_pm2_5: 20, us_aqi_pm10: 22, us_aqi_ozone: 88 }), "Ozone");
+  assert.equal(dominant({ us_aqi_pm2_5: 10, us_aqi_pm10: 61 }), "PM10");
+  assert.equal(dominant({}), null);
+  assert.equal(dominant({ us_aqi_pm2_5: null }), null);
+});
+
+test("peakNext24: max within the next 24h window (unixtime seconds)", () => {
+  const nowMs = 1_700_000_000_000, nowS = 1_700_000_000;
+  const times = [nowS - 3600, nowS + 3600, nowS + 7200, nowS + 90000]; // last is >24h out
+  const values = [40, 60, 55, 200];
+  const peak = peakNext24(times, values, nowMs);
+  assert.equal(peak.aqi, 60);            // 200 is beyond 24h; 40 is in the past
+  assert.equal(peak.at, nowS + 3600);
+});
+
+test("peakNext24: bad input -> null", () => {
+  assert.equal(peakNext24(null, null, 1_700_000_000_000), null);
+  assert.equal(peakNext24([], [], 1_700_000_000_000), null);
+});

--- a/web/index.html
+++ b/web/index.html
@@ -168,7 +168,7 @@
   .rain-fact .v{color:var(--ink);font-weight:800;}
 
   /* ---- tiles ---- */
-  .tiles{display:grid;grid-template-columns:repeat(2,1fr);gap:12px;}
+  .tiles{display:grid;grid-template-columns:repeat(2,1fr);gap:12px;position:relative;z-index:20;}
   .tile{padding:14px 15px 15px;display:flex;flex-direction:column;gap:6px;background:var(--glass-bg);border:1px solid var(--glass-brd);border-radius:var(--radius-sm);box-shadow:inset 0 1px 0 var(--glass-hi),0 10px 26px -18px rgba(58,22,10,.5);backdrop-filter:var(--blur);-webkit-backdrop-filter:var(--blur);}
   .tile-top{display:flex;align-items:center;gap:8px;}
   .tile-top .ico{width:26px;height:26px;flex:none;color:var(--coral-deep);}
@@ -191,6 +191,29 @@
   .chip{display:inline-block;padding:2px 9px;border-radius:999px;font-size:.68rem;font-weight:800;letter-spacing:.4px;text-transform:uppercase;}
   .chip.veryhigh{background:rgba(232,69,31,.16);color:var(--coral-deep);}
   .chip.falling{background:rgba(15,127,143,.16);color:var(--teal-deep);}
+  /* AQI category chips (US AQI colors, tuned for contrast on the light glass tiles) */
+  .chip.aqi-good{background:#3fa34d;color:#eafff0;}
+  .chip.aqi-moderate{background:#e6b800;color:#2b1c00;}
+  .chip.aqi-usg{background:#ff8c2b;color:#2b1400;}
+  .chip.aqi-unhealthy{background:#ef3b3b;color:#fff;}
+  .chip.aqi-veryunhealthy{background:#8e5bc0;color:#fff;}
+  .chip.aqi-hazardous{background:#8b2f3a;color:#fff;}
+  /* Air Quality full-width panel (spans all columns at both breakpoints → no dangling slot) */
+  .tile.aqi-panel{grid-column:1 / -1;position:relative;}
+  .aqi-row{display:flex;align-items:center;justify-content:space-between;gap:10px 12px;flex-wrap:wrap;margin-top:2px;}
+  .aqi-main{display:flex;align-items:center;gap:9px;}
+  .aqi-num{font-size:2.1rem;font-weight:800;line-height:1;letter-spacing:-1px;}
+  .aqi-break{display:flex;gap:6px;flex-wrap:wrap;}
+  .aqi-break .p{display:flex;flex-direction:column;align-items:center;line-height:1.15;cursor:pointer;background:none;border:0;font:inherit;color:inherit;padding:2px 5px;border-radius:8px;}
+  .aqi-break .p:hover,.aqi-break .p[aria-expanded="true"]{background:rgba(43,24,16,.12);}
+  .aqi-break .p b{font-size:1.05rem;font-weight:800;font-variant-numeric:tabular-nums;color:var(--ink);}
+  .aqi-break .p span{font-size:.6rem;font-weight:800;letter-spacing:.5px;text-transform:uppercase;color:var(--ink-soft);margin-top:2px;border-bottom:1px dotted currentColor;}
+  /* click-to-open help balloon (dark tooltip on the light tile) */
+  .aqi-pop{position:absolute;z-index:6;max-width:min(300px,86%);background:#0c3a49;border:1px solid rgba(255,255,255,.18);border-radius:12px;padding:10px 12px;box-shadow:0 16px 36px -10px rgba(0,0,0,.55);}
+  .aqi-pop b{display:block;font-size:.86rem;font-weight:800;color:#f2fbfc;margin-bottom:3px;}
+  .aqi-pop .d{display:block;font-size:.78rem;line-height:1.42;color:rgba(234,246,248,.86);font-weight:600;}
+  .aqi-pop .s{display:block;margin-top:6px;font-size:.7rem;font-weight:800;color:#ffce7a;}
+  .aqi-pop .cx{position:absolute;top:-6px;width:11px;height:11px;transform:translateX(-50%) rotate(45deg);background:#0c3a49;border-left:1px solid rgba(255,255,255,.18);border-top:1px solid rgba(255,255,255,.18);}
   .uvbar{height:7px;border-radius:999px;margin-top:4px;background:linear-gradient(90deg,#4caf50,#cddc39,#ffc107,#ff7043,#e53935,#8e24aa);position:relative;}
   .uvbar span{content:"";position:absolute;top:-3px;width:13px;height:13px;transform:translateX(-50%);border-radius:50%;background:#fff;border:2px solid var(--coral-deep);box-shadow:0 2px 6px rgba(0,0,0,.3);}
 
@@ -522,6 +545,15 @@
         <div class="tile-top"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 3v18M7 6h5M7 11h4M7 16h5"/><path d="M17 3v18"/></svg><span class="t">24h Range</span></div>
         <div class="tile-val"><span id="hi">--</span>&deg; <small>/ <span id="lo">--</span>&deg;F</small></div>
         <div class="tile-sub">High &middot; Low</div>
+      </div>
+      <div class="tile aqi-panel" id="aqiTile">
+        <div class="tile-top"><svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 9h13a3 3 0 1 0-3-3"/><path d="M2 14h16a3 3 0 1 1-3 3"/></svg><span class="t">Air Quality</span></div>
+        <div class="aqi-row">
+          <div class="aqi-main"><span class="aqi-num" id="aqi">--</span><span class="chip" id="aqiChip" hidden></span></div>
+          <div class="aqi-break" id="aqiBreak"></div>
+        </div>
+        <div class="tile-sub" id="aqiSub">&mdash;</div>
+        <div class="aqi-pop" id="aqiPop" role="dialog" aria-label="Pollutant info" hidden><span class="cx" id="aqiPopCx" aria-hidden="true"></span><b id="aqiPopT"></b><span class="d" id="aqiPopD"></span><span class="s" id="aqiPopS"></span></div>
       </div>
     </section>
 
@@ -961,15 +993,68 @@
     trEl.className="wtr-t-trend "+(trend==="rising"?"up":trend==="draining"?"down":"");
   }
 
+  /* -- air quality tile (Open-Meteo / CAMS, US AQI) -- */
+  var AQI_SHORT={good:"Good",moderate:"Moderate",usg:"Sensitive",unhealthy:"Unhealthy",veryunhealthy:"Very Unhealthy",hazardous:"Hazardous"};
+  async function loadAir(){
+    try{
+      var r=await fetch(API+"/api/air",{cache:"no-store"});
+      var d=await r.json();
+      var tile=$("aqiTile");
+      if(!d||d.aqi==null){if(tile)tile.hidden=true;return;}
+      if(tile)tile.hidden=false;
+      set("aqi",d.aqi);
+      var chip=$("aqiChip");chip.hidden=false;
+      chip.textContent=AQI_SHORT[d.categorySlug]||d.category||"";
+      chip.className="chip"+(d.categorySlug?" aqi-"+d.categorySlug:"");
+      closeAqiPop();
+      var p=d.pollutants||{}, items=[["pm25","PM2.5",p.pm25],["pm10","PM10",p.pm10],["ozone","Ozone",p.ozone],["dust","Dust",p.dust]];
+      $("aqiBreak").innerHTML=items.filter(function(it){return it[2]!=null;}).map(function(it){
+        return '<button type="button" class="p" data-k="'+it[0]+'" aria-expanded="false" title="'+it[1]+' — tap for info"><b>'+it[2]+'</b><span>'+it[1]+'</span></button>';
+      }).join("");
+      var sub=[];
+      if(d.dominant)sub.push(d.dominant+" driving");
+      sub.push("µg/m³ · modeled (CAMS)");
+      if(d.peak&&d.peak.aqi>d.aqi+2){ // flag only a meaningfully worse next-24h peak
+        var t=new Date(d.peak.at*1000).toLocaleTimeString("en-US",{timeZone:"America/Los_Angeles",hour:"numeric"});
+        sub.push("↑ "+d.peak.aqi+" by "+t);
+      }
+      $("aqiSub").textContent=sub.join(" · ");
+    }catch(e){}
+  }
+  /* pollutant help balloon — click a pollutant for a plain-language explainer + scale */
+  var POLL_INFO={
+    pm25:{t:"PM2.5 — fine particles",d:"Tiny particles 2.5 microns or smaller — smoke, soot and haze. Small enough to reach deep into the lungs, so it drives most health alerts.",s:"µg/m³ · ~0–12 good, 35+ unhealthy (24-hr)"},
+    pm10:{t:"PM10 — coarse particles",d:"Larger particles up to 10 microns: wind-blown dust, pollen and smoke.",s:"µg/m³ · ~0–54 good, 155+ unhealthy"},
+    ozone:{t:"Ozone (O₃)",d:"Ground-level ozone forms in sunlight from vehicle and industrial emissions; it builds on hot, sunny afternoons.",s:"µg/m³ · higher on hot, sunny days"},
+    dust:{t:"Dust",d:"Airborne mineral dust from blowing dust and haboobs — common across the desert Southwest.",s:"µg/m³ · spikes with wind"},
+  };
+  var aqiPop=$("aqiPop"), aqiActive=null;
+  function closeAqiPop(){ if(aqiActive)aqiActive.setAttribute("aria-expanded","false"); aqiActive=null; aqiPop.hidden=true; }
+  function openAqiPop(btn){
+    var info=POLL_INFO[btn.dataset.k]; if(!info)return;
+    $("aqiPopT").textContent=info.t; $("aqiPopD").textContent=info.d; $("aqiPopS").textContent=info.s;
+    aqiPop.hidden=false;
+    var pw=$("aqiTile").clientWidth, popW=aqiPop.offsetWidth, cxpx=btn.offsetLeft+btn.offsetWidth/2;
+    var left=Math.max(8,Math.min(cxpx-popW/2, pw-popW-8));
+    aqiPop.style.left=left+"px"; aqiPop.style.top=(btn.offsetTop+btn.offsetHeight+9)+"px";
+    $("aqiPopCx").style.left=(cxpx-left)+"px";
+    if(aqiActive)aqiActive.setAttribute("aria-expanded","false");
+    btn.setAttribute("aria-expanded","true"); aqiActive=btn;
+  }
+  $("aqiBreak").addEventListener("click",function(e){ var b=e.target.closest(".p"); if(!b)return; (aqiActive===b?closeAqiPop:openAqiPop)(b); });
+  document.addEventListener("click",function(e){ if(aqiActive&&!e.target.closest("#aqiPop")&&!e.target.closest("#aqiBreak"))closeAqiPop(); });
+  document.addEventListener("keydown",function(e){ if(e.key==="Escape")closeAqiPop(); });
+
   /* ---------- go ---------- */
   loadCurrent();loadHistory(24);
-  loadAlerts();loadForecast();loadCompare();loadWater();
+  loadAlerts();loadForecast();loadCompare();loadWater();loadAir();
   setInterval(loadCurrent,60000);
   setInterval(function(){loadHistory(rangeHours);},300000);
   setInterval(loadAlerts,300000);
   setInterval(loadForecast,900000);
   setInterval(loadCompare,300000);
   setInterval(loadWater,1800000);
+  setInterval(loadAir,1800000);
 })();
 </script>
 <script>

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,6 +1,6 @@
 /* Havasu Lake Weather — service worker (installability + offline shell) */
-const CACHE = "havasu-wx-v39";  // bump on EVERY web/ change (cache correctness; CI-enforced)
-const RELEASE = "r3";           // bump ONLY for user-facing changes — drives the "update available" toast
+const CACHE = "havasu-wx-v40";  // bump on EVERY web/ change (cache correctness; CI-enforced)
+const RELEASE = "r4";           // bump ONLY for user-facing changes — drives the "update available" toast
 const SHELL = [
   "/", "/index.html", "/water.html", "/radar.html", "/manifest.json", "/sw-register.js",
   "/assets/icon-192.png", "/assets/icon-512.png", "/assets/icon-180.png",


### PR DESCRIPTION
Closes #88.

A full-width home-page **Air Quality** panel backed by a new **keyless `/api/air`** (Open-Meteo / CAMS, modeled at the lake's exact coords — better than a far-off EPA monitor for a remote spot).

## What's in it
- **`/api/air`** (`air.js`): US AQI + category, **dominant pollutant** (argmax of `us_aqi_*` sub-indices), **PM2.5 / PM10 / Ozone / Dust** concentrations, and a **next-24h peak** from the hourly series. Cached 1h, soft-fails. Pure helpers (`aqiCategory` / `dominant` / `peakNext24`) unit-tested.
- **Full-width panel** (`grid-column:1/-1`) — fixes the dangling 5th-tile slot at both breakpoints. Big AQI + color-coded category chip + pollutant breakdown; "PM2.5 driving · modeled (CAMS)"; a conditional "↑ NN by \<time\>" peak heads-up (shows only when the next-24h AQI is meaningfully worse).
- **Per-pollutant help balloons** — each pollutant is a button that opens a plain-language explainer + scale (Esc / tap-away / tapping another closes; `aria-expanded`). `.tiles` lifted to `z-index:20` so the balloon renders above the panel below instead of being clipped.
- **SW** `v40`/`r4`; **`npm test` 71/71** (`air.test.mjs`).

## Notes
- Modeled (CAMS), not an EPA monitor — labeled as such. Wildfire-smoke/dust is the seasonal hook here.
- Keyless (no new secrets). Ingest-only + web change → both deploy jobs run on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHfTY9b4p18XoeNJPactfL