### PR TITLE
HLW-048 (Phase 1): ingest accepts Ecowitt POST-body uploads

### DIFF
--- a/docs/issues/HLW-048-lightning-ingest.md
+++ b/docs/issues/HLW-048-lightning-ingest.md
@@ -1,0 +1,47 @@
+# HLW-048: Lightning (Ambient WH31L via Ecowitt GW1100) — ingest + display
+
+- **Status:** in-progress — Phase 1 (ingest POST-body parsing) building; hardware + display pending.
+- **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/91
+- **Branch:** `feat/HLW-048-lightning-ingest`
+- **PR:** _(opens once the gateway is posting; Phase 1 build waits on the branch)_
+- **Created:** 2026-09-01
+
+## Summary
+
+Surface **lightning** on the site from an **Ambient WH31L** detector, received by an **Ecowitt
+GW1100** gateway. The WS-2902 console can't take the WH31L (Ambient supports it only on
+WS-2000/4000/5000/1965), so the GW1100 receives it and does a **Customized upload (Ecowitt
+protocol)** to our existing ingest endpoint. We display strike distance / daily count / last strike.
+
+## Why the gateway (decided)
+
+- WH31L is **not** WS-2902-compatible (Ambient's own compat list). Confirmed.
+- WH31L is Fine-Offset OEM (same lightning module as Ecowitt's WH57); Ecowitt GW1100/GW2000 are
+  **widely reported** to receive it (community-confirmed, not vendor-guaranteed) → **pairing test first**.
+- Alternative (rejected for now): an Ambient WS-2000/5000 console (official, but a pricier full
+  console + routes via AmbientWeather.net → a new Ambient-API data path).
+
+## Hardware (Chad)
+
+1. Power the **GW1100** (USB) near Wi-Fi; add it in the Ecowitt app (join its hotspot → hand it 2.4 GHz Wi-Fi).
+2. Batteries into the **WH31L**; confirm a lightning sensor appears in the app's **Sensors** list (pairing test).
+3. App → gateway → **Weather Services → Customized**: protocol **Ecowitt**, server
+   `dzn7sq96yz34g.cloudfront.net` (bare host), path `/data/report/?`, port `80`, interval 60 s.
+
+## Build
+
+- [ ] **Phase 1 — ingest POST-body parsing** (`ingest/src/handler.js`): Ecowitt posts fields in the
+      request **body** (urlencoded); today `parseParams` reads only GET query params (WS-2902 style).
+      Parse `event.body` (decode base64 when `isBase64Encoded`) as a fallback between query-string and
+      rawPath. Export `parseParams` + unit test (GET, POST body, base64, path-jammed). Build only — no
+      deploy until the gateway posts. Ecowitt is HTTP-only; our ingest already takes HTTP :80.
+- [ ] **Phase 2 — capture** (after GW1100 posts): read the raw payload from the ingest logs → exact
+      lightning field names + the gateway PASSKEY (empirical, like WH31E's `temp1f`).
+- [ ] **Phase 3 — surface**: add the gateway key to `ALLOWED_STATION_KEYS`; read the newest lightning
+      reading; show strike distance / daily count / "last strike NN min ago" on the site.
+
+## Notes
+
+- WH31L is a **separate uploader** (its own PASSKEY) → its own `OBS#<key>` partition; the read side
+  merges it into the display (the WS-2902 keeps posting the array + WH31E on its own key).
+- 79-second transmit cadence; ~25-mile detection range; 2×AA (lithium recommended).

--- a/ingest/src/handler.js
+++ b/ingest/src/handler.js
@@ -49,9 +49,16 @@ const prevMonth = (yyyymm) => {
   return `${y}-${String(m).padStart(2, "0")}`;
 };
 
-function parseParams(event) {
+export function parseParams(event) {
   const q = event?.queryStringParameters;
   if (q && Object.keys(q).length) return q;
+  // Ecowitt gateways (e.g. a GW1100 relaying the WH31L lightning sensor) POST the fields as
+  // urlencoded form data; the WS-2902 uses a GET query string. Parse the body too (base64-safe).
+  if (event?.body) {
+    const decoded = event.isBase64Encoded ? Buffer.from(event.body, "base64").toString("utf8") : event.body;
+    const b = Object.fromEntries(new URLSearchParams(decoded));
+    if (Object.keys(b).length) return b;
+  }
   // Fallback: some firmware jams params into the path with no '?'.
   const raw = event?.rawPath || "";
   const i = raw.search(/[?&]/);

--- a/ingest/src/handler.js
+++ b/ingest/src/handler.js
@@ -94,7 +94,7 @@ export const handler = async (event) => {
     return ok();
   }
   if (ALLOWED.length && !ALLOWED.includes(stationKey)) {
-    console.log(JSON.stringify({ msg: "skip-unlisted", receivedAt, stationKey }));
+    console.log(JSON.stringify({ msg: "skip-unlisted", receivedAt, stationKey, keys: Object.keys(p) }));
     return ok();
   }
 

--- a/ingest/test/ingest-params.test.mjs
+++ b/ingest/test/ingest-params.test.mjs
@@ -1,0 +1,43 @@
+// Unit tests for parseParams(event) from ingest/src/handler.js (HLW-048).
+// The WS-2902 uploads via GET query string; an Ecowitt gateway (GW1100 relaying the WH31L)
+// POSTs urlencoded form data — parseParams must read both. No AWS/network.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseParams } from "../src/handler.js";
+
+test("GET query string (WS-2902 style)", () => {
+  const p = parseParams({ queryStringParameters: { PASSKEY: "ABC", tempf: "101.2" } });
+  assert.equal(p.PASSKEY, "ABC");
+  assert.equal(p.tempf, "101.2");
+});
+
+test("POST urlencoded body (Ecowitt gateway style)", () => {
+  const p = parseParams({ body: "PASSKEY=GW1&stationtype=GW1100&lightning_num=3&lightning=12" });
+  assert.equal(p.PASSKEY, "GW1");
+  assert.equal(p.stationtype, "GW1100");
+  assert.equal(p.lightning_num, "3");
+  assert.equal(p.lightning, "12");
+});
+
+test("base64-encoded POST body decodes", () => {
+  const raw = "PASSKEY=GW1&lightning_time=1788300000";
+  const p = parseParams({ body: Buffer.from(raw, "utf8").toString("base64"), isBase64Encoded: true });
+  assert.equal(p.PASSKEY, "GW1");
+  assert.equal(p.lightning_time, "1788300000");
+});
+
+test("query string wins over body when both present", () => {
+  const p = parseParams({ queryStringParameters: { PASSKEY: "Q" }, body: "PASSKEY=B" });
+  assert.equal(p.PASSKEY, "Q");
+});
+
+test("path-jammed params fallback (some firmware)", () => {
+  const p = parseParams({ rawPath: "/data/report/?PASSKEY=P&humidity=40" });
+  assert.equal(p.PASSKEY, "P");
+  assert.equal(p.humidity, "40");
+});
+
+test("empty event -> {}", () => {
+  assert.deepEqual(parseParams({}), {});
+  assert.deepEqual(parseParams({ body: "" }), {});
+});


### PR DESCRIPTION
Refs #91. Phase 1 of lightning (Ambient WH31L via Ecowitt GW1100 — pairing confirmed).

The GW1100 does a **Customized upload in the Ecowitt protocol, which POSTs the fields in the request body**; our ingest's `parseParams` only read the **GET query string** (WS-2902 style). This teaches it to also parse the POST body (urlencoded, base64-safe), and logs the field keys on `skip-unlisted` so the gateway's first upload reveals its PASSKEY + field names for onboarding.

- `ingest/src/handler.js`: `parseParams` now reads query → **body** → path-jammed; exported.
- `ingest/test/ingest-params.test.mjs`: GET / POST body / base64 / precedence / path-jammed. `npm test` **77/77**.
- Infra already OK: the ingest CloudFront allows POST (verified in the deployed template).

**Why deploy this before the display:** the gateway's data can't land until the ingest parses POST bodies. Once merged + the GW1100 is posting, I'll read the payload from the logs, add its key to `ALLOWED_STATION_KEYS`, and build the lightning display (Phase 2/3, separate PR).

Ingest-only → site job skips on merge; ingest job redeploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHfTY9b4p18XoeNJPactfL