### PR TITLE
HLW-048: lightning bolt meter + Rain & Storms page (WH31L via GW1100)

### DIFF
--- a/docs/issues/HLW-048-lightning-ingest.md
+++ b/docs/issues/HLW-048-lightning-ingest.md
@@ -1,6 +1,6 @@
 # HLW-048: Lightning (Ambient WH31L via Ecowitt GW1100) — ingest + display
 
-- **Status:** in-progress — Phase 1 (ingest POST-body parsing) building; hardware + display pending.
+- **Status:** in-progress — Phase 1 shipped (#92); gateway online + WH31L paired + posting (fields captured: `lightning`, `lightning_num`, `lightning_time`, `wh57batt`). Full build (bolt meter + /rain page) previewed; pending: gateway-key deploy + PR merge.
 - **GitHub issue:** https://github.com/cwoskoski/havasulakeweather/issues/91
 - **Branch:** `feat/HLW-048-lightning-ingest`
 - **PR:** _(opens once the gateway is posting; Phase 1 build waits on the branch)_
@@ -30,15 +30,26 @@ protocol)** to our existing ingest endpoint. We display strike distance / daily 
 
 ## Build
 
-- [ ] **Phase 1 — ingest POST-body parsing** (`ingest/src/handler.js`): Ecowitt posts fields in the
+- [x] **Phase 1 — ingest POST-body parsing (shipped in PR #92)** (`ingest/src/handler.js`): Ecowitt posts fields in the
       request **body** (urlencoded); today `parseParams` reads only GET query params (WS-2902 style).
       Parse `event.body` (decode base64 when `isBase64Encoded`) as a fallback between query-string and
       rawPath. Export `parseParams` + unit test (GET, POST body, base64, path-jammed). Build only — no
       deploy until the gateway posts. Ecowitt is HTTP-only; our ingest already takes HTTP :80.
-- [ ] **Phase 2 — capture** (after GW1100 posts): read the raw payload from the ingest logs → exact
-      lightning field names + the gateway PASSKEY (empirical, like WH31E's `temp1f`).
-- [ ] **Phase 3 — surface**: add the gateway key to `ALLOWED_STATION_KEYS`; read the newest lightning
-      reading; show strike distance / daily count / "last strike NN min ago" on the site.
+- [x] **Phase 2 — captured**: gateway posting; fields `lightning` (km), `lightning_num` (today), `lightning_time` (epoch), `wh57batt` (the gateway IDs the WH31L as its WH57 twin). Gateway PASSKEY seen in logs (E819…).
+- [x] **Phase 3 — built + previewed** (this PR):
+      - `lightning.js`: pure helpers — 0–3 **bolt level** (quiet/distant/area/close via recency+proximity+rate,
+        midnight-reset-safe strike counting), km→mi, mock scenarios.
+      - `handler.js`: lightning fields → `NUMERIC`; **per-station rain watermark** (a shared mark would let
+        two posting stations corrupt each other's rain detection).
+      - `read.js`: `lightning` block on `/api/current` + new **`/api/lightning`** (`?hours=`, `?mock=quiet|distant|close`).
+      - Home rain card: **0–3 bolt meter** (flickers at level ≥2, reduced-motion safe) + status line + **Storms →**.
+      - **`/rain.html` "Rain & Storms"**: hero (rain + bolts), **range-ring strike display** (distance-only-honest),
+        strikes/hour + distance-trend chart (24h), rainfall totals + dry streak, 7-day rain chances, **sky-flash**
+        (random while active; fires on a real counter increment; reduced-motion off). SEO head, sitemap, footers, SW v41/r5.
+      - Tests 85/85 (`lightning.test.mjs` + earlier suites).
+- [ ] **Ship**: merge PR (code deploy) → then the gated **key deploy** (manual `sam deploy` adding the gateway
+      PASSKEY to `AllowedStationKeys` — read back from live per house rules) → verify gateway rows in DynamoDB →
+      bolt meter goes live on real data.
 
 ## Notes
 

--- a/ingest/src/handler.js
+++ b/ingest/src/handler.js
@@ -34,11 +34,16 @@ const NUMERIC = new Set([
   "baromrelin", "baromabsin", "battout",
   // WH31E extra thermo-hygrometer, CH1 (shaded air temp). battN: 1 = OK, 0 = low.
   "temp1f", "humidity1", "batt1",
+  // WH31L lightning detector via the Ecowitt GW1100 gateway (reported as "wh57"):
+  // last-strike distance (km), strikes today, last-strike epoch, battery.
+  "lightning", "lightning_num", "lightning_time", "wh57batt",
 ]);
 
-// In-memory watermark, survives across warm invocations (~1/min keeps us warm):
-// { dateutc, totalrainin, lastRainAt }. Null until the first invocation seeds it.
-let mark = null;
+// In-memory watermarks, survive across warm invocations (~1/min keeps us warm):
+// stationKey -> { dateutc, totalrainin, lastRainAt }. Per-station since HLW-048 —
+// the WS-2902 and the GW1100 gateway both post, and a single shared mark would
+// let one station's totals corrupt the other's rain detection.
+const marks = new Map();
 
 const ok = () => ({ statusCode: 200, headers: { "content-type": "text/plain" }, body: "success\n" });
 const num = (v) => { const n = Number(v); return Number.isFinite(n) ? n : v; };
@@ -108,7 +113,8 @@ export const handler = async (event) => {
   }
 
   try {
-    if (!mark) mark = await seedFromDb(stationKey, yyyymm); // cold start only
+    let mark = marks.get(stationKey);
+    if (!mark) { mark = await seedFromDb(stationKey, yyyymm); if (mark) marks.set(stationKey, mark); } // cold start only
 
     let rainingNow = false;
     let lastRainAt = mark?.lastRainAt ?? null;
@@ -127,9 +133,9 @@ export const handler = async (event) => {
       ConditionExpression: "attribute_not_exists(pk)",
     })).catch((e) => { if (e.name !== "ConditionalCheckFailedException") throw e; });
 
-    // Advance the watermark (forward only; ignores retries/out-of-order posts).
+    // Advance this station's watermark (forward only; ignores retries/out-of-order posts).
     if (!mark || iso > mark.dateutc) {
-      mark = { dateutc: iso, totalrainin: reading.totalrainin, lastRainAt };
+      marks.set(stationKey, { dateutc: iso, totalrainin: reading.totalrainin, lastRainAt });
     }
 
     console.log(JSON.stringify({ msg: "stored", stationKey, dateutc: iso, tempf: reading.tempf, rainingNow }));

--- a/ingest/src/lightning.js
+++ b/ingest/src/lightning.js
@@ -1,0 +1,105 @@
+/**
+ * Havasu Lake Weather — lightning helpers (HLW-048).
+ *
+ * The Ambient WH31L (received by the Ecowitt GW1100 gateway) reports, per upload:
+ *   lightning       — distance of the LAST strike (km)
+ *   lightning_num   — strikes so far today (daily counter, resets at midnight)
+ *   lightning_time  — epoch seconds of the last strike
+ *   wh57batt        — battery (the gateway identifies the WH31L as its WH57 twin)
+ *
+ * From the stored per-minute readings we derive a 0–3 "bolt level":
+ *   0 quiet   — no strikes in the last 60 min
+ *   1 distant — strikes in the last 60 min, but far (>15 mi) or stale-30
+ *   2 area    — strikes in the last 30 min within ~15 mi
+ *   3 close   — strikes in the last ~20 min within ~6 mi
+ */
+
+export const kmToMi = (km) => (km == null || !Number.isFinite(km) ? null : +(km * 0.621371).toFixed(1));
+
+const num = (v) => { const n = Number(v); return Number.isFinite(n) ? n : null; };
+
+// Strikes within [sinceMs, now]: sum of positive deltas of the daily counter across
+// consecutive readings in the window. A negative delta is the midnight reset — the
+// post-reset counter value IS the strikes since reset, so add it as-is.
+export function strikesInWindow(points, sinceMs) {
+  let total = 0, prev = null;
+  for (const p of points || []) {
+    const t = Date.parse(p.t), n = num(p.num);
+    if (n == null || !Number.isFinite(t)) continue;
+    if (t < sinceMs) { prev = n; continue; } // last pre-window reading = baseline
+    if (prev != null) total += n >= prev ? n - prev : n;
+    prev = n;
+  }
+  return total;
+}
+
+// Nearest strike distance (mi) among readings whose last-strike time falls in the window.
+export function nearestInWindow(points, sinceSec) {
+  let best = null;
+  for (const p of points || []) {
+    const at = num(p.strikeAt), d = num(p.distMi);
+    if (at == null || d == null || at < sinceSec) continue;
+    if (best == null || d < best) best = d;
+  }
+  return best;
+}
+
+// The agreed 0–3 ladder.
+export function boltLevel({ s60 = 0, s30 = 0, s20 = 0, nearest30Mi = null, nearest20Mi = null }) {
+  if (!s60) return 0;
+  if (s20 > 0 && nearest20Mi != null && nearest20Mi <= 6) return 3;
+  if (s30 > 0 && nearest30Mi != null && nearest30Mi <= 15) return 2;
+  return 1;
+}
+
+// Full summary from the recent-window series + the newest gateway reading.
+export function summarize(points, latest, nowMs = Date.now()) {
+  const nowSec = Math.floor(nowMs / 1000);
+  const s60 = strikesInWindow(points, nowMs - 60 * 60000);
+  const s30 = strikesInWindow(points, nowMs - 30 * 60000);
+  const s20 = strikesInWindow(points, nowMs - 20 * 60000);
+  const nearest30Mi = nearestInWindow(points, nowSec - 30 * 60);
+  const nearest20Mi = nearestInWindow(points, nowSec - 20 * 60);
+  const level = boltLevel({ s60, s30, s20, nearest30Mi, nearest20Mi });
+  const lastAt = num(latest?.lightning_time);
+  return {
+    level,
+    strikes60: s60,
+    countToday: num(latest?.lightning_num) ?? 0,
+    nearestMi: nearest30Mi ?? kmToMi(num(latest?.lightning)),
+    lastStrikeAt: lastAt ? new Date(lastAt * 1000).toISOString() : null,
+    battLow: num(latest?.wh57batt) != null ? num(latest?.wh57batt) <= 1 : null,
+  };
+}
+
+// Mock scenarios so every bolt level is previewable on a clear desert day.
+export function mockLightning(scenario, nowMs = Date.now()) {
+  const nowSec = Math.floor(nowMs / 1000);
+  const mk = (level, countToday, nearestMi, agoMin, strikes60) => ({
+    source: "mock", mock: scenario,
+    current: { level, strikes60, countToday, nearestMi, lastStrikeAt: agoMin == null ? null : new Date((nowSec - agoMin * 60) * 1000).toISOString(), battLow: false },
+    series: mockSeries(scenario, nowMs),
+  });
+  if (scenario === "close") return mk(3, 42, 3.1, 4, 18);
+  if (scenario === "distant") return mk(1, 7, 19.9, 41, 3);
+  return mk(0, 0, null, null, 0); // quiet
+}
+
+function mockSeries(scenario, nowMs) {
+  const pts = [];
+  const active = scenario === "close" ? 26 : scenario === "distant" ? 7 : 0;
+  let count = 0;
+  for (let m = 240; m >= 0; m -= 5) {
+    const t = new Date(nowMs - m * 60000);
+    const inStorm = scenario !== "quiet" && m < 150;
+    if (inStorm && Math.random() < (scenario === "close" ? 0.75 : 0.3)) count += scenario === "close" ? 2 : 1;
+    const base = scenario === "close" ? 22 - (150 - m) * 0.12 : 24 - (150 - m) * 0.03;
+    pts.push({
+      t: t.toISOString(),
+      num: Math.min(count, active),
+      distMi: inStorm && count ? +Math.max(2, base + (Math.random() * 3 - 1.5)).toFixed(1) : null,
+      strikeAt: inStorm && count ? Math.floor(t.getTime() / 1000) : null,
+    });
+  }
+  return pts;
+}

--- a/ingest/src/read.js
+++ b/ingest/src/read.js
@@ -16,13 +16,17 @@ import { getCompare } from "./compare.js";
 import { getWater } from "./water.js";
 import { getRadar } from "./radar.js";
 import { getAir } from "./air.js";
+import { kmToMi, summarize, mockLightning } from "./lightning.js";
 
 const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 const TABLE = process.env.TABLE_NAME;
-const STATION = (process.env.STATION_KEY || "").split(",")[0].trim();
+const KEYS = (process.env.STATION_KEY || "").split(",").map((s) => s.trim()).filter(Boolean);
+const STATION = KEYS[0] || "";
+const LIGHTNING_KEY = KEYS[1] || ""; // GW1100 gateway (WH31L lightning) — 2nd allowed key
 const RAIN_DEBOUNCE_MIN = Number(process.env.RAIN_DEBOUNCE_MIN || 15); // stay "raining" until the rate has read 0 this long
 
-const obsPk = (mm) => `OBS#${STATION}#${mm}`;
+const obsPkFor = (key, mm) => `OBS#${key}#${mm}`;
+const obsPk = (mm) => obsPkFor(STATION, mm);
 const ym = (d) => d.toISOString().slice(0, 7);
 const prevMonth = (mm) => { let [y, m] = mm.split("-").map(Number); if (--m === 0) { m = 12; y--; } return `${y}-${String(m).padStart(2, "0")}`; };
 const nextMonth = (mm) => { let [y, m] = mm.split("-").map(Number); if (++m === 13) { m = 1; y++; } return `${y}-${String(m).padStart(2, "0")}`; };
@@ -122,6 +126,51 @@ async function rainWindow(minutes) {
   return items;
 }
 
+// Lightning (WH31L via the GW1100 gateway, HLW-048): gateway readings mapped to chart
+// points; also feeds the 0–3 bolt level via summarize().
+async function lightningPoints(hours) {
+  const now = new Date();
+  const startISO = new Date(now - hours * 3600e3).toISOString().slice(0, 19) + "Z";
+  const months = [ym(new Date(now - hours * 3600e3)), ym(now)].filter((v, i, a) => a.indexOf(v) === i);
+  const items = [];
+  for (const mm of months) {
+    let ek;
+    do {
+      const r = await ddb.send(new QueryCommand({
+        TableName: TABLE,
+        KeyConditionExpression: "pk = :pk AND sk >= :s",
+        ExpressionAttributeValues: { ":pk": obsPkFor(LIGHTNING_KEY, mm), ":s": startISO },
+        ProjectionExpression: "sk, lightning, lightning_num, lightning_time, wh57batt",
+        ExclusiveStartKey: ek,
+      }));
+      items.push(...(r.Items || []));
+      ek = r.LastEvaluatedKey;
+    } while (ek);
+  }
+  items.sort((a, b) => (a.sk < b.sk ? -1 : 1));
+  return items.map((r) => ({
+    t: r.sk,
+    num: toNum(r.lightning_num),
+    distMi: kmToMi(toNum(r.lightning)),
+    strikeAt: toNum(r.lightning_time),
+    batt: toNum(r.wh57batt),
+  }));
+}
+
+// Current lightning summary for /api/current — null when no gateway is configured/reporting.
+async function getLightningCurrent() {
+  if (!LIGHTNING_KEY) return null;
+  const pts = await lightningPoints(1.5); // 90 min: the 60-min window + a baseline reading
+  if (!pts.length) return null;
+  const last = pts[pts.length - 1];
+  return summarize(pts, {
+    lightning_num: last.num,
+    lightning: last.distMi == null ? null : last.distMi / 0.621371, // summarize expects km
+    lightning_time: last.strikeAt,
+    wh57batt: last.batt,
+  });
+}
+
 // Normalize "raining now". This station reports `hourlyrainin` as a rain RATE (it
 // exceeds the daily/total counters and decays smoothly), so key off that instead of
 // the tipping-bucket delta — which only ticks when the 0.01" bucket tips and so flaps
@@ -151,7 +200,11 @@ export const handler = async (event) => {
       // the extra sensor drops out, so the page can fall back to the array.
       const shadeTf = toNum(it.temp1f), shadeRh = toNum(it.humidity1);
       const ageSec = it.receivedAt ? (Date.now() - Date.parse(it.receivedAt)) / 1000 : null;
-      const rain = rainState(await rainWindow(RAIN_DEBOUNCE_MIN), it);
+      const [rainRecent, lightning] = await Promise.all([
+        rainWindow(RAIN_DEBOUNCE_MIN),
+        getLightningCurrent().catch(() => null), // soft-fail: no lightning ≠ no weather
+      ]);
+      const rain = rainState(rainRecent, it);
       return res(200, {
         station: STATION,
         observedAt: it.dateutc,
@@ -170,6 +223,7 @@ export const handler = async (event) => {
         uv: it.uv,
         solarWm2: it.solarradiation,
         rain: { rainingNow: rain.rainingNow, rateInHr: rain.rateInHr, lastRainAt: rain.lastRainAt, todayIn: it.dailyrainin, monthIn: it.monthlyrainin, yearIn: it.yearlyrainin },
+        lightning,
       }, 30);
     }
 
@@ -263,7 +317,28 @@ export const handler = async (event) => {
       }
     }
 
-    return res(404, { error: "not found", try: ["/api/current", "/api/history?hours=24", "/api/forecast", "/api/alerts", "/api/compare", "/api/water", "/api/radar", "/api/air"] }, 15);
+    // Lightning: current bolt-level summary + a series for the /rain page charts.
+    // ?mock=quiet|distant|close previews every level on a clear desert day.
+    if (path.endsWith("/api/lightning")) {
+      if (qs.mock) return res(200, mockLightning(qs.mock), 20);
+      try {
+        let hours = parseInt(qs.hours || "24", 10);
+        if (!Number.isFinite(hours) || hours <= 0) hours = 24;
+        hours = Math.min(hours, 72);
+        if (!LIGHTNING_KEY) return res(200, { source: "live", hours, current: null, series: [], note: "no gateway configured" }, 300);
+        const series = await lightningPoints(hours);
+        const last = series[series.length - 1] || null;
+        const current = last
+          ? summarize(series, { lightning_num: last.num, lightning: last.distMi == null ? null : last.distMi / 0.621371, lightning_time: last.strikeAt, wh57batt: last.batt })
+          : null;
+        return res(200, { source: "live", hours, current, series }, 60);
+      } catch (e) {
+        console.error(JSON.stringify({ msg: "lightning-upstream", error: String(e?.message || e) }));
+        return res(200, { source: "live", current: null, series: [], error: "upstream" }, 30);
+      }
+    }
+
+    return res(404, { error: "not found", try: ["/api/current", "/api/history?hours=24", "/api/forecast", "/api/alerts", "/api/compare", "/api/water", "/api/radar", "/api/air", "/api/lightning"] }, 15);
   } catch (e) {
     console.error(JSON.stringify({ msg: "read-error", error: String(e?.message || e), path }));
     return res(500, { error: "internal" }, 5);

--- a/ingest/test/lightning.test.mjs
+++ b/ingest/test/lightning.test.mjs
@@ -1,0 +1,81 @@
+// Unit tests for the lightning helpers in ingest/src/lightning.js (HLW-048). No AWS/network.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { kmToMi, strikesInWindow, nearestInWindow, boltLevel, summarize, mockLightning } from "../src/lightning.js";
+
+const T0 = Date.UTC(2026, 8, 1, 20, 0, 0); // fixed "now"
+const iso = (minAgo) => new Date(T0 - minAgo * 60000).toISOString();
+
+test("kmToMi converts and guards", () => {
+  assert.equal(kmToMi(10), 6.2);
+  assert.equal(kmToMi(0), 0);
+  assert.equal(kmToMi(null), null);
+  assert.equal(kmToMi(NaN), null);
+});
+
+test("strikesInWindow sums positive deltas, baseline from pre-window reading", () => {
+  const pts = [
+    { t: iso(70), num: 10 }, // pre-window baseline
+    { t: iso(50), num: 12 }, // +2
+    { t: iso(30), num: 12 }, // +0
+    { t: iso(10), num: 15 }, // +3
+  ];
+  assert.equal(strikesInWindow(pts, T0 - 60 * 60000), 5);
+});
+
+test("strikesInWindow handles the midnight counter reset", () => {
+  const pts = [
+    { t: iso(50), num: 40 },
+    { t: iso(30), num: 3 },  // reset: counter dropped, 3 new strikes since midnight
+    { t: iso(10), num: 5 },  // +2
+  ];
+  assert.equal(strikesInWindow(pts, T0 - 60 * 60000), 5);
+});
+
+test("strikesInWindow: empty/no-data -> 0", () => {
+  assert.equal(strikesInWindow([], T0), 0);
+  assert.equal(strikesInWindow([{ t: iso(5), num: null }], T0 - 3600e3), 0);
+});
+
+test("nearestInWindow filters by strike time and takes the min", () => {
+  const s = Math.floor(T0 / 1000);
+  const pts = [
+    { distMi: 4.0, strikeAt: s - 50 * 60 }, // outside 30-min window
+    { distMi: 12.4, strikeAt: s - 25 * 60 },
+    { distMi: 8.1, strikeAt: s - 5 * 60 },
+  ];
+  assert.equal(nearestInWindow(pts, s - 30 * 60), 8.1);
+  assert.equal(nearestInWindow(pts, s - 60 * 60), 4.0);
+  assert.equal(nearestInWindow([], s), null);
+});
+
+test("boltLevel ladder matches the agreed thresholds", () => {
+  assert.equal(boltLevel({ s60: 0 }), 0);
+  assert.equal(boltLevel({ s60: 3, s30: 0 }), 1);                                    // only stale-30 activity
+  assert.equal(boltLevel({ s60: 3, s30: 2, nearest30Mi: 22 }), 1);                    // active but far
+  assert.equal(boltLevel({ s60: 5, s30: 4, nearest30Mi: 12 }), 2);                    // storm in the area
+  assert.equal(boltLevel({ s60: 9, s30: 8, s20: 5, nearest30Mi: 9, nearest20Mi: 4.5 }), 3); // close
+  assert.equal(boltLevel({ s60: 9, s30: 8, s20: 5, nearest30Mi: 9, nearest20Mi: 9 }), 2);   // recent but not close
+});
+
+test("summarize composes level + count + last-strike ISO", () => {
+  const s = Math.floor(T0 / 1000);
+  const pts = [
+    { t: iso(70), num: 0 },
+    { t: iso(15), num: 6, distMi: 5.0, strikeAt: s - 15 * 60 },
+    { t: iso(5), num: 9, distMi: 4.2, strikeAt: s - 5 * 60 },
+  ];
+  const out = summarize(pts, { lightning_num: 9, lightning: 6.8, lightning_time: s - 300, wh57batt: 4 }, T0);
+  assert.equal(out.level, 3);
+  assert.equal(out.countToday, 9);
+  assert.equal(out.nearestMi, 4.2);
+  assert.equal(out.lastStrikeAt, new Date((s - 300) * 1000).toISOString());
+  assert.equal(out.battLow, false);
+});
+
+test("mock scenarios hit the intended bolt levels", () => {
+  assert.equal(mockLightning("quiet", T0).current.level, 0);
+  assert.equal(mockLightning("distant", T0).current.level, 1);
+  assert.equal(mockLightning("close", T0).current.level, 3);
+  assert.ok(mockLightning("close", T0).series.length > 10);
+});

--- a/web/index.html
+++ b/web/index.html
@@ -164,6 +164,21 @@
   @media (max-width:430px){ .rain-radar{top:12px;right:12px;padding:8px 13px;font-size:.85rem;} .rain-radar .ico{width:16px;height:16px;} .rain-lead{padding-right:92px;} .rain-lead .status{font-size:1.5rem;} }
   .rain-facts{grid-column:1 / -1;display:grid;grid-template-columns:repeat(2,1fr);gap:8px 14px;padding-top:12px;border-top:1px solid rgba(43,24,16,.14);}
   .rain-fact{display:flex;justify-content:space-between;font-size:.82rem;}
+  /* Lightning bolt meter (0–3, WH31L via gateway) — links to /rain.html */
+  .rain-bolts{grid-column:1 / -1;display:flex;align-items:center;gap:10px;padding-top:11px;border-top:1px solid rgba(43,24,16,.14);text-decoration:none;color:inherit;}
+  .rain-bolts .bolts{display:inline-flex;gap:3px;flex:none;}
+  .rain-bolts .bolts svg{width:17px;height:17px;fill:rgba(43,24,16,.20);transition:fill .3s ease;}
+  .rain-bolts.l1 .b1{fill:#e8a20c;}
+  .rain-bolts.l2 .b1,.rain-bolts.l2 .b2{fill:#ff8a3d;}
+  .rain-bolts.l3 .b1,.rain-bolts.l3 .b2,.rain-bolts.l3 .b3{fill:#e8451f;}
+  .rain-bolts .btxt{flex:1;font-size:.82rem;font-weight:650;color:var(--ink-soft);}
+  .rain-bolts .btxt b{color:var(--ink);font-weight:800;}
+  .rain-bolts .bmore{flex:none;font-size:.8rem;font-weight:800;color:var(--teal-deep);white-space:nowrap;}
+  @media (prefers-reduced-motion: no-preference){
+    .rain-bolts.l2 .bolts,.rain-bolts.l3 .bolts{animation:boltFlicker 3.4s infinite;}
+    .rain-bolts.l3 .bolts{animation-duration:2.1s;}
+  }
+  @keyframes boltFlicker{0%,88%{opacity:1}90%{opacity:.35}92%{opacity:1}95%{opacity:.55}97%,100%{opacity:1}}
   .rain-fact .k{color:var(--ink-soft);font-weight:650;}
   .rain-fact .v{color:var(--ink);font-weight:800;}
 
@@ -508,6 +523,11 @@
         <div class="rain-fact"><span class="k">This month</span><span class="v" id="rainMonth">--</span></div>
         <div class="rain-fact"><span class="k">This year</span><span class="v" id="rainYear">--</span></div>
       </div>
+      <a class="rain-bolts" id="boltRow" href="/rain.html" hidden>
+        <span class="bolts" id="boltIcons" aria-hidden="true"><svg class="b1" viewBox="0 0 24 24"><path d="M13 2 4 14h6l-2 8 10-13h-6l1-7z"/></svg><svg class="b2" viewBox="0 0 24 24"><path d="M13 2 4 14h6l-2 8 10-13h-6l1-7z"/></svg><svg class="b3" viewBox="0 0 24 24"><path d="M13 2 4 14h6l-2 8 10-13h-6l1-7z"/></svg></span>
+        <span class="btxt" id="boltText">&mdash;</span>
+        <span class="bmore">Storms &rarr;</span>
+      </a>
     </section>
 
     <!-- FORECAST (NWS) -->
@@ -666,7 +686,7 @@
     <footer class="footer">
       <div>Personal WS-2902D weather station &mdash; not an official observation.</div>
       <div>Havasu Lake, CA &middot; Ambient Weather &middot; Outdoor readings only</div>
-      <nav class="ftnav" aria-label="Site"><a href="/">Live conditions</a> &middot; <a href="/radar.html">Radar</a> &middot; <a href="/water.html">Lake Havasu water level</a></nav>
+      <nav class="ftnav" aria-label="Site"><a href="/">Live conditions</a> &middot; <a href="/radar.html">Radar</a> &middot; <a href="/water.html">Lake Havasu water level</a> &middot; <a href="/rain.html">Rain &amp; storms</a></nav>
     </footer>
   </main>
 
@@ -754,11 +774,38 @@
       set("rainMonth",fmtIn(d.rain.monthIn));
       set("rainYear",fmtIn(d.rain.yearIn));
       set("lastRain",d.rain.lastRainAt?rel(d.rain.lastRainAt):"none logged");
+      renderBolts(d.lightning);
       lastReceived=d.receivedAt?Date.parse(d.receivedAt):Date.now();
       isStale=!!d.stale;
       tickAgo();
     }catch(e){$("freshText").textContent="Offline — retrying…";}
   }
+  /* Lightning bolt meter (0–3). Hidden until the detector is reporting; a ?mockLightning=
+     quiet|distant|close override lets every level be previewed on a clear day. */
+  var MOCK_L=null; // sticky mock override — beats live data on every refresh
+  function renderBolts(L){
+    var row=$("boltRow");if(!row)return;
+    L=MOCK_L||L;
+    if(!L){row.hidden=true;return;}
+    row.hidden=false;
+    row.classList.remove("l1","l2","l3");
+    if(L.level>=1)row.classList.add("l"+Math.min(3,L.level));
+    if(L.level===0){
+      $("boltText").innerHTML="No lightning nearby"+(L.countToday?" &middot; "+L.countToday+" today":"");
+    }else{
+      var bits=[];
+      if(L.nearestMi!=null)bits.push("nearest ~<b>"+Math.round(L.nearestMi)+" mi</b>");
+      if(L.countToday!=null)bits.push("<b>"+L.countToday+"</b> today");
+      if(L.lastStrikeAt)bits.push("last "+rel(L.lastStrikeAt));
+      $("boltText").innerHTML="Lightning &middot; "+bits.join(" &middot; ");
+    }
+  }
+  (function(){ /* mock override so the meter is previewable without a storm */
+    var m=new URLSearchParams(location.search).get("mockLightning");
+    if(!m)return;
+    fetch(API+"/api/lightning?mock="+encodeURIComponent(m),{cache:"no-store"})
+      .then(function(r){return r.json();}).then(function(j){MOCK_L=j.current;renderBolts(null);}).catch(function(){});
+  })();
   function uvLevel(u){if(u==null)return"";if(u>=11)return"Extreme";if(u>=8)return"Very High";if(u>=6)return"High";if(u>=3)return"Moderate";return"Low";}
   function fmtIn(v){return (v==null?0:v).toFixed(2)+" in";}
   function rel(iso){var s=(Date.now()-Date.parse(iso))/1000;if(s<90)return"just now";var m=s/60;if(m<90)return Math.round(m)+" min ago";var h=m/60;if(h<36)return Math.round(h)+"h ago";return Math.round(h/24)+" days ago";}

--- a/web/radar.html
+++ b/web/radar.html
@@ -119,7 +119,7 @@
       future radar (HRRR): <a href="https://mesonet.agron.iastate.edu/" target="_blank" rel="noopener">Iowa Environmental Mesonet</a> &middot;
       map &copy; OpenStreetMap / CARTO &middot; community reference, not an official product.
       <a href="/water.html">Lake &amp; river &rarr;</a>
-      <nav class="ftnav" aria-label="Site"><a href="/">Live conditions</a> &middot; <a href="/water.html">Lake Havasu water level</a> &middot; <a href="/radar.html">Radar</a></nav>
+      <nav class="ftnav" aria-label="Site"><a href="/">Live conditions</a> &middot; <a href="/water.html">Lake Havasu water level</a> &middot; <a href="/radar.html">Radar</a> &middot; <a href="/rain.html">Rain &amp; storms</a></nav>
     </div>
   </main>
 

--- a/web/rain.html
+++ b/web/rain.html
@@ -1,0 +1,353 @@
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+<meta name="theme-color" content="#0e4a5e" />
+<link rel="manifest" href="/manifest.json" />
+<link rel="icon" type="image/png" href="/assets/icon-192.png" />
+<link rel="apple-touch-icon" href="/assets/icon-180.png" />
+<meta name="apple-mobile-web-app-capable" content="yes" />
+<meta name="apple-mobile-web-app-title" content="Havasu Wx" />
+<meta name="description" content="Rain and storms for Havasu Lake, CA — live lightning detection (strikes, distance and trend from an on-site detector), rainfall totals, and storm outlook." />
+<title>Rain &amp; Storms — Havasu Lake, CA (Live Lightning &amp; Rainfall)</title>
+<link rel="canonical" href="https://havasulakeweather.com/rain.html" />
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="Havasu Lake Weather" />
+<meta property="og:title" content="Rain &amp; Storms — Havasu Lake, CA (Live Lightning &amp; Rainfall)" />
+<meta property="og:description" content="Live lightning detection and rainfall for Havasu Lake, California — strikes, distance trend, rain totals and the storm outlook, from an on-site detector." />
+<meta property="og:url" content="https://havasulakeweather.com/rain.html" />
+<meta property="og:image" content="https://havasulakeweather.com/assets/og-image.png" />
+<meta property="og:image:type" content="image/png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="Rain &amp; Storms — Havasu Lake, CA" />
+<meta name="twitter:description" content="Live lightning detection and rainfall for Havasu Lake, California." />
+<meta name="twitter:image" content="https://havasulakeweather.com/assets/og-image.png" />
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    { "@type": "WebPage", "@id": "https://havasulakeweather.com/rain.html#webpage", "url": "https://havasulakeweather.com/rain.html", "name": "Rain & Storms — Havasu Lake, CA (Live Lightning & Rainfall)", "isPartOf": { "@id": "https://havasulakeweather.com/#website" }, "about": { "@id": "https://havasulakeweather.com/#place" }, "description": "Live lightning detection and rainfall for Havasu Lake, California — strike counts, distance trend, rainfall totals and storm outlook from an on-site detector." },
+    { "@type": "BreadcrumbList", "@id": "https://havasulakeweather.com/rain.html#breadcrumb", "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Havasu Lake, CA Weather", "item": "https://havasulakeweather.com/" },
+      { "@type": "ListItem", "position": 2, "name": "Rain & Storms" }
+    ] }
+  ]
+}
+</script>
+<!-- Google Analytics (GA4) — loads only on the live domain. -->
+<script>
+  (function () {
+    var h = location.hostname;
+    if (h !== "havasulakeweather.com" && h !== "www.havasulakeweather.com") return;
+    var s = document.createElement("script");
+    s.async = true; s.src = "https://www.googletagmanager.com/gtag/js?id=G-NTKCW8E330";
+    document.head.appendChild(s);
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){ dataLayer.push(arguments); }
+    window.gtag = gtag; gtag("js", new Date()); gtag("config", "G-NTKCW8E330");
+  })();
+</script>
+<style>
+  :root{
+    --ink:#eaf6f8;--ink-soft:rgba(234,246,248,.72);--ink-faint:rgba(234,246,248,.5);
+    --coral:#ff7a4d;--coral-deep:#ff8f68;--gold:#ffbf5c;--teal:#2fb9c4;--teal-deep:#7fe6e2;
+    --glass:rgba(10,42,52,.55);--glass-2:rgba(255,255,255,.06);--brd:rgba(255,255,255,.16);
+    --radius:22px;--font:ui-rounded,"SF Pro Rounded","Segoe UI",system-ui,-apple-system,"Helvetica Neue",Arial,sans-serif;
+    --shadow:0 18px 44px -18px rgba(0,0,0,.6);
+  }
+  *{box-sizing:border-box;} html,body{margin:0;padding:0;}
+  body{font-family:var(--font);color:var(--ink);background:linear-gradient(180deg,#0d3a49 0%,#0a2b34 60%,#08222a 100%);min-height:100vh;-webkit-font-smoothing:antialiased;}
+  .wnav{position:sticky;top:0;z-index:1000;display:flex;align-items:center;gap:12px;padding:max(12px,env(safe-area-inset-top)) 16px 12px;background:rgba(8,34,42,.72);backdrop-filter:blur(12px) saturate(150%);-webkit-backdrop-filter:blur(12px) saturate(150%);border-bottom:1px solid rgba(255,255,255,.08);}
+  .wnav a.back{display:inline-flex;align-items:center;gap:7px;color:var(--ink);text-decoration:none;font-weight:800;font-size:.92rem;background:rgba(255,255,255,.08);border:1px solid var(--brd);border-radius:999px;padding:8px 14px;}
+  .wnav .title{font-weight:800;font-size:1.02rem;} .wnav .title small{display:block;font-weight:600;font-size:.68rem;color:var(--ink-faint);}
+  .rpage{max-width:760px;margin:0 auto;padding:14px 14px calc(24px + env(safe-area-inset-bottom));display:flex;flex-direction:column;gap:12px;position:relative;z-index:1;}
+  .card{background:var(--glass);border:1px solid var(--brd);border-radius:var(--radius);box-shadow:var(--shadow);backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);padding:16px 18px;}
+  .card h2{margin:0 0 4px;font-size:.8rem;font-weight:800;letter-spacing:.6px;text-transform:uppercase;color:var(--ink-faint);}
+  .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;}
+  /* hero */
+  .hero-row{display:flex;align-items:center;justify-content:space-between;gap:14px;flex-wrap:wrap;}
+  .hero-main .status{font-size:1.9rem;font-weight:800;line-height:1.05;}
+  .hero-main .status .pill{display:inline-block;margin-left:8px;vertical-align:middle;background:rgba(47,185,196,.2);color:var(--teal-deep);border-radius:999px;padding:3px 11px;font-size:.7rem;font-weight:800;letter-spacing:.4px;text-transform:uppercase;}
+  .hero-main .sub{margin-top:4px;font-size:.86rem;font-weight:650;color:var(--ink-soft);}
+  .bolts{display:inline-flex;gap:5px;}
+  .bolts svg{width:30px;height:30px;fill:rgba(255,255,255,.16);transition:fill .3s ease;filter:drop-shadow(0 2px 6px rgba(0,0,0,.4));}
+  .hero-bolts{display:flex;flex-direction:column;align-items:center;gap:4px;}
+  .hero-bolts .lbl{font-size:.62rem;font-weight:800;letter-spacing:.6px;text-transform:uppercase;color:var(--ink-faint);}
+  .l1 .b1{fill:var(--gold);}
+  .l2 .b1,.l2 .b2{fill:#ffa14d;}
+  .l3 .b1,.l3 .b2,.l3 .b3{fill:var(--coral);}
+  .facts{display:grid;grid-template-columns:repeat(3,1fr);gap:8px;margin-top:14px;padding-top:12px;border-top:1px solid rgba(255,255,255,.1);}
+  .fact{display:flex;flex-direction:column;gap:2px;}
+  .fact .k{font-size:.62rem;font-weight:800;letter-spacing:.5px;text-transform:uppercase;color:var(--ink-faint);}
+  .fact .v{font-size:1.05rem;font-weight:800;}
+  .fact .v small{font-size:.75rem;font-weight:700;color:var(--ink-soft);}
+  /* rings */
+  .rings-wrap{display:flex;justify-content:center;}
+  .rings-note{text-align:center;font-size:.74rem;font-weight:600;color:var(--ink-faint);margin-top:4px;line-height:1.4;}
+  svg.rings{width:min(320px,86vw);height:auto;display:block;}
+  .ringc{fill:none;stroke:rgba(255,255,255,.14);stroke-width:1;}
+  .ringlbl{fill:rgba(234,246,248,.45);font-size:8px;font-weight:700;font-family:var(--font);}
+  .center-dot{fill:#ffd24a;}
+  .sring{fill:none;stroke:var(--gold);stroke-width:2;}
+  @media (prefers-reduced-motion: no-preference){
+    .sring{animation:ringPulse 2.6s ease-out infinite;}
+    @keyframes ringPulse{0%{stroke-width:3;stroke-opacity:1}70%{stroke-width:1.2;stroke-opacity:.35}100%{stroke-width:3;stroke-opacity:1}}
+  }
+  /* charts */
+  .chart svg{display:block;width:100%;height:auto;}
+  .legend{display:flex;gap:16px;font-size:.7rem;font-weight:700;color:var(--ink-faint);margin:2px 0 8px;}
+  .legend i{display:inline-block;width:12px;height:8px;border-radius:2px;margin-right:5px;}
+  /* forecast strip */
+  .pops{display:flex;gap:6px;overflow-x:auto;padding:6px 0 2px;scrollbar-width:none;}
+  .pop{flex:0 0 auto;min-width:74px;text-align:center;background:var(--glass-2);border:1px solid var(--brd);border-radius:14px;padding:9px 8px;}
+  .pop .d{font-size:.68rem;font-weight:800;color:var(--ink-soft);}
+  .pop .p{font-size:1.05rem;font-weight:800;color:var(--teal-deep);margin-top:2px;}
+  .pop .p.dry{color:var(--ink-faint);}
+  /* sky flash */
+  #skyFlash{position:fixed;inset:0;background:radial-gradient(ellipse at 50% -10%,rgba(240,250,255,.95),rgba(200,230,245,.35) 45%,transparent 75%);opacity:0;pointer-events:none;z-index:2000;}
+  #skyFlash.go{animation:skyFlashAnim .55s ease-out;}
+  @keyframes skyFlashAnim{0%{opacity:0}8%{opacity:.85}18%{opacity:.15}30%{opacity:.6}100%{opacity:0}}
+  @media (prefers-reduced-motion: reduce){ #skyFlash{display:none;} }
+  .foot{text-align:center;font-size:.72rem;color:var(--ink-faint);line-height:1.5;}
+  .foot a{color:var(--ink-soft);}
+  .ftnav{margin-top:8px;font-weight:700;}
+  .ftnav a{color:var(--ink-soft);white-space:nowrap;}
+</style>
+</head>
+<body>
+  <div id="skyFlash" aria-hidden="true"></div>
+  <header class="wnav">
+    <a class="back" href="/">&larr; Conditions</a>
+    <div class="title">Rain &amp; Storms<small>Havasu Lake, CA &middot; on-site lightning detector</small></div>
+  </header>
+
+  <main class="rpage">
+    <h1 class="sr-only">Havasu Lake, CA Rain &amp; Storms — Live Lightning Detection and Rainfall</h1>
+
+    <!-- HERO -->
+    <section class="card" aria-label="Current rain and lightning">
+      <div class="hero-row">
+        <div class="hero-main">
+          <div class="status" id="rainStatus">&mdash;<span class="pill" id="rainPill" hidden></span></div>
+          <div class="sub" id="rainSub">Checking the gauge&hellip;</div>
+        </div>
+        <div class="hero-bolts">
+          <span class="bolts" id="heroBolts" aria-hidden="true"><svg class="b1" viewBox="0 0 24 24"><path d="M13 2 4 14h6l-2 8 10-13h-6l1-7z"/></svg><svg class="b2" viewBox="0 0 24 24"><path d="M13 2 4 14h6l-2 8 10-13h-6l1-7z"/></svg><svg class="b3" viewBox="0 0 24 24"><path d="M13 2 4 14h6l-2 8 10-13h-6l1-7z"/></svg></span>
+          <span class="lbl" id="boltLbl">Lightning</span>
+        </div>
+      </div>
+      <div class="facts">
+        <div class="fact"><span class="k">Strikes today</span><span class="v" id="fCount">--</span></div>
+        <div class="fact"><span class="k">Nearest (30 min)</span><span class="v" id="fNearest">--</span></div>
+        <div class="fact"><span class="k">Last strike</span><span class="v" id="fLast">--</span></div>
+      </div>
+    </section>
+
+    <!-- RANGE RINGS -->
+    <section class="card" aria-labelledby="rings-h">
+      <h2 id="rings-h">Strike distance — last hour</h2>
+      <div class="rings-wrap">
+        <svg class="rings" viewBox="0 0 300 300" role="img" aria-label="Lightning strike distances on range rings">
+          <g id="ringBase"></g>
+          <g id="ringStrikes"></g>
+          <circle class="center-dot" cx="150" cy="150" r="4"/>
+          <text class="ringlbl" x="150" y="292" text-anchor="middle">Havasu Lake at center &middot; rings = miles</text>
+        </svg>
+      </div>
+      <div class="rings-note" id="ringsNote">The detector senses distance, not direction — each ring pulse marks how far a recent strike was.</div>
+    </section>
+
+    <!-- ACTIVITY -->
+    <section class="card chart" aria-labelledby="act-h">
+      <h2 id="act-h">Lightning activity — last 24 h</h2>
+      <div class="legend"><span><i style="background:var(--gold)"></i>Strikes / hour</span><span><i style="background:var(--teal-deep)"></i>Strike distance (mi)</span></div>
+      <svg id="actSvg" viewBox="0 0 700 240" role="img" aria-label="Strikes per hour and strike distance over 24 hours">
+        <g id="actGrid" stroke="rgba(255,255,255,0.10)" stroke-width="1"></g>
+        <g id="actBars"></g>
+        <g id="actDots"></g>
+        <g id="actLabels" fill="rgba(234,246,248,0.5)" font-size="11" font-weight="700" font-family="sans-serif"></g>
+      </svg>
+      <div class="rings-note" id="actNote"></div>
+    </section>
+
+    <!-- RAIN -->
+    <section class="card" aria-labelledby="rain-h2">
+      <h2 id="rain-h2">Rainfall</h2>
+      <div class="facts" style="border-top:none;padding-top:2px;margin-top:2px;">
+        <div class="fact"><span class="k">Today</span><span class="v" id="rToday">--</span></div>
+        <div class="fact"><span class="k">This month</span><span class="v" id="rMonth">--</span></div>
+        <div class="fact"><span class="k">This year</span><span class="v" id="rYear">--</span></div>
+      </div>
+      <div class="facts" style="grid-template-columns:1fr;border-top:1px solid rgba(255,255,255,.1);">
+        <div class="fact"><span class="k">Dry streak</span><span class="v" id="rStreak">--</span></div>
+      </div>
+    </section>
+
+    <!-- STORM OUTLOOK -->
+    <section class="card" aria-labelledby="fc-h">
+      <h2 id="fc-h">Rain chances — next 7 days</h2>
+      <div class="pops" id="pops"></div>
+    </section>
+
+    <div class="foot">
+      Lightning: on-site <b>Ambient WH31L</b> detector (distance only, ~25-mile range) &middot; community reference, not an official product.
+      <a href="/radar.html">Live radar &rarr;</a>
+      <nav class="ftnav" aria-label="Site"><a href="/">Live conditions</a> &middot; <a href="/radar.html">Radar</a> &middot; <a href="/water.html">Lake Havasu water level</a> &middot; <a href="/rain.html">Rain &amp; storms</a></nav>
+    </div>
+  </main>
+
+<script>
+(function(){
+  var $=function(id){return document.getElementById(id);};
+  var API="";
+  var Q=new URLSearchParams(location.search), MOCK=Q.get("mockLightning");
+  var reduced=window.matchMedia&&window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  var lastCount=null, level=0, flashTimer=null;
+  var fmtT=function(iso){return new Date(iso).toLocaleTimeString("en-US",{timeZone:"America/Los_Angeles",hour:"numeric",minute:"2-digit"});};
+  var rel=function(iso){var s=(Date.now()-Date.parse(iso))/1000;if(s<90)return"just now";var m=s/60;if(m<90)return Math.round(m)+" min ago";var h=m/60;if(h<36)return Math.round(h)+"h ago";return Math.round(h/24)+" days ago";};
+  var fmtIn=function(v){return (v==null?0:v).toFixed(2)+" in";};
+
+  /* ---------- range rings ---------- */
+  var RINGS=[5,10,15,25], RMAX=25, RPX=132;
+  (function(){
+    var g=$("ringBase"),html="";
+    RINGS.forEach(function(mi){
+      var r=mi/RMAX*RPX;
+      html+='<circle class="ringc" cx="150" cy="150" r="'+r.toFixed(1)+'"/>';
+      html+='<text class="ringlbl" x="150" y="'+(150-r-3).toFixed(1)+'" text-anchor="middle">'+mi+'</text>';
+    });
+    g.innerHTML=html;
+  })();
+  function drawStrikeRings(series){
+    var nowS=Date.now()/1000, cut=nowS-3600, out="", seen={},n=0;
+    for(var i=series.length-1;i>=0&&n<12;i--){
+      var p=series[i];
+      if(p.strikeAt==null||p.distMi==null||p.strikeAt<cut)continue;
+      var key=p.strikeAt+":"+p.distMi;
+      if(seen[key])continue;seen[key]=1;
+      var r=Math.min(p.distMi,RMAX)/RMAX*RPX;
+      var age=(nowS-p.strikeAt)/3600; // 0..1
+      out+='<circle class="sring" cx="150" cy="150" r="'+r.toFixed(1)+'" style="stroke-opacity:'+(1-age*0.75).toFixed(2)+';animation-delay:'+((n*0.4)%2).toFixed(1)+'s"/>';
+      n++;
+    }
+    $("ringStrikes").innerHTML=out;
+    if(!n)$("ringsNote").textContent="No strikes in the last hour. The detector senses distance, not direction — during a storm, ring pulses mark how far each strike was.";
+  }
+
+  /* ---------- activity chart ---------- */
+  function drawActivity(series){
+    var W=700,H=240,PB=26,PT=12;
+    var grid=$("actGrid"),bars=$("actBars"),dots=$("actDots"),labels=$("actLabels");
+    grid.innerHTML="";bars.innerHTML="";dots.innerHTML="";labels.innerHTML="";
+    if(!series.length){$("actNote").textContent="No detector data yet.";return;}
+    var now=Date.now(), buckets=new Array(24).fill(0), prev=null;
+    series.forEach(function(p){
+      if(p.num==null)return;
+      if(prev!=null){
+        var d=p.num>=prev?p.num-prev:p.num;
+        if(d>0){
+          var hrAgo=Math.floor((now-Date.parse(p.t))/3600e3);
+          if(hrAgo>=0&&hrAgo<24)buckets[23-hrAgo]+=d;
+        }
+      }
+      prev=p.num;
+    });
+    var maxB=Math.max.apply(null,buckets.concat([4]));
+    var bw=(W-20)/24;
+    for(var i=0;i<24;i++){
+      var h=buckets[i]/maxB*(H-PB-PT);
+      if(buckets[i]>0)bars.insertAdjacentHTML("beforeend",'<rect x="'+(10+i*bw+2).toFixed(1)+'" y="'+(H-PB-h).toFixed(1)+'" width="'+(bw-4).toFixed(1)+'" height="'+h.toFixed(1)+'" rx="3" fill="var(--gold)" fill-opacity="0.85"/>');
+    }
+    [0.25,0.5,0.75,1].forEach(function(f){
+      var y=H-PB-f*(H-PB-PT);
+      grid.insertAdjacentHTML("beforeend",'<line x1="10" y1="'+y.toFixed(1)+'" x2="690" y2="'+y.toFixed(1)+'"/>');
+      labels.insertAdjacentHTML("beforeend",'<text x="688" y="'+(y-3).toFixed(1)+'" text-anchor="end">'+Math.round(f*maxB)+'</text>');
+    });
+    // distance dots (right scale 0–25 mi)
+    series.forEach(function(p){
+      if(p.strikeAt==null||p.distMi==null)return;
+      var ageMs=now-p.strikeAt*1000;
+      if(ageMs<0||ageMs>24*3600e3)return;
+      var x=10+(1-ageMs/(24*3600e3))*(W-20);
+      var y=PT+(Math.min(p.distMi,RMAX)/RMAX)*(H-PB-PT);
+      dots.insertAdjacentHTML("beforeend",'<circle cx="'+x.toFixed(1)+'" cy="'+y.toFixed(1)+'" r="2.6" fill="var(--teal-deep)" fill-opacity="0.9"/>');
+    });
+    labels.insertAdjacentHTML("beforeend",'<text x="10" y="'+(H-8)+'">24h ago</text><text x="690" y="'+(H-8)+'" text-anchor="end">now</text>');
+    labels.insertAdjacentHTML("beforeend",'<text x="10" y="'+(PT+8)+'">25 mi</text>');
+    var total=buckets.reduce(function(a,b){return a+b;},0);
+    $("actNote").textContent=total?total+" strikes detected in the last 24 hours.":"No strikes detected in the last 24 hours.";
+  }
+
+  /* ---------- hero + flash ---------- */
+  function renderLightning(cur){
+    var b=$("heroBolts");
+    b.classList.remove("l1","l2","l3");
+    if(!cur){$("boltLbl").textContent="Detector offline";$("fCount").textContent="--";$("fNearest").textContent="--";$("fLast").textContent="--";level=0;return;}
+    level=cur.level||0;
+    if(level>=1)b.classList.add("l"+Math.min(3,level));
+    $("boltLbl").textContent=["Quiet","Distant","In the area","Close!"][level]||"Lightning";
+    $("fCount").textContent=cur.countToday!=null?cur.countToday:"--";
+    $("fNearest").innerHTML=cur.nearestMi!=null?("~"+Math.round(cur.nearestMi)+" <small>mi</small>"):"&mdash;";
+    $("fLast").textContent=cur.lastStrikeAt?rel(cur.lastStrikeAt):"none";
+    if(lastCount!=null&&cur.countToday>lastCount)flash(); // a real strike just registered
+    lastCount=cur.countToday;
+    scheduleFlashes();
+  }
+  function flash(){ if(reduced)return; var f=$("skyFlash"); f.classList.remove("go"); void f.offsetWidth; f.classList.add("go"); }
+  function scheduleFlashes(){
+    clearTimeout(flashTimer);
+    if(reduced||level<2)return;
+    var wait=(level===3?6000:13000)+Math.random()*(level===3?8000:11000);
+    flashTimer=setTimeout(function(){flash();scheduleFlashes();},wait);
+  }
+
+  /* ---------- loads ---------- */
+  function loadLightning(){
+    var url=MOCK?(API+"/api/lightning?mock="+encodeURIComponent(MOCK)):(API+"/api/lightning?hours=24");
+    return fetch(url,{cache:"no-store"}).then(function(r){return r.json();}).then(function(j){
+      renderLightning(j.current);
+      drawStrikeRings(j.series||[]);
+      drawActivity(j.series||[]);
+    }).catch(function(){});
+  }
+  function loadRain(){
+    return fetch(API+"/api/current",{cache:"no-store"}).then(function(r){return r.json();}).then(function(d){
+      var raining=!!(d.rain&&d.rain.rainingNow);
+      $("rainStatus").firstChild.textContent=raining?"Raining":"Dry";
+      var pill=$("rainPill");pill.hidden=false;pill.textContent=raining?"Now":"Not raining";
+      $("rainSub").textContent=raining
+        ?("Rain falling on the station"+(d.rain.rateInHr?(" · "+d.rain.rateInHr.toFixed(2)+" in/hr"):""))
+        :"No rain on the station right now.";
+      $("rToday").textContent=fmtIn(d.rain&&d.rain.todayIn);
+      $("rMonth").textContent=fmtIn(d.rain&&d.rain.monthIn);
+      $("rYear").textContent=fmtIn(d.rain&&d.rain.yearIn);
+      var streak=$("rStreak");
+      if(raining)streak.textContent="Raining now";
+      else if(d.rain&&d.rain.lastRainAt){
+        var days=Math.floor((Date.now()-Date.parse(d.rain.lastRainAt))/86400e3);
+        streak.textContent=days<1?"Rained today":days+" day"+(days===1?"":"s")+" since last rain";
+      } else streak.textContent="No rain logged";
+    }).catch(function(){});
+  }
+  function loadPops(){
+    return fetch(API+"/api/forecast",{cache:"no-store"}).then(function(r){return r.json();}).then(function(d){
+      var days=(d.daily||[]).filter(function(x){return x.isDaytime!==false;}).slice(0,7);
+      $("pops").innerHTML=days.map(function(x){
+        var p=x.precipProb!=null?x.precipProb:0;
+        return '<div class="pop"><div class="d">'+(x.name||"")+'</div><div class="p'+(p<15?" dry":"")+'">'+p+'%</div></div>';
+      }).join("")||'<div class="rings-note">Forecast unavailable.</div>';
+    }).catch(function(){});
+  }
+
+  loadLightning();loadRain();loadPops();
+  setInterval(loadLightning,60000);
+  setInterval(loadRain,120000);
+  document.addEventListener("visibilitychange",function(){ if(document.hidden)clearTimeout(flashTimer); else scheduleFlashes(); });
+})();
+</script>
+<script src="/sw-register.js" defer></script>
+</body>
+</html>

--- a/web/sitemap.xml
+++ b/web/sitemap.xml
@@ -18,4 +18,10 @@
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
+  <url>
+    <loc>https://havasulakeweather.com/rain.html</loc>
+    <lastmod>2026-09-01</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+  </url>
 </urlset>

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,8 +1,8 @@
 /* Havasu Lake Weather — service worker (installability + offline shell) */
-const CACHE = "havasu-wx-v40";  // bump on EVERY web/ change (cache correctness; CI-enforced)
-const RELEASE = "r4";           // bump ONLY for user-facing changes — drives the "update available" toast
+const CACHE = "havasu-wx-v41";  // bump on EVERY web/ change (cache correctness; CI-enforced)
+const RELEASE = "r5";           // bump ONLY for user-facing changes — drives the "update available" toast
 const SHELL = [
-  "/", "/index.html", "/water.html", "/radar.html", "/manifest.json", "/sw-register.js",
+  "/", "/index.html", "/water.html", "/radar.html", "/rain.html", "/manifest.json", "/sw-register.js",
   "/assets/icon-192.png", "/assets/icon-512.png", "/assets/icon-180.png",
   "/assets/venmo-qr.png", "/assets/cashapp-qr.png",
 ];

--- a/web/water.html
+++ b/web/water.html
@@ -254,7 +254,7 @@
     <div class="foot">
       Lake level: USGS · Dam releases &amp; water temp: USBR RISE · updates ~hourly.<br>
       Community reference only &mdash; not an official forecast. <a href="/">&larr; back to conditions</a>
-      <nav class="ftnav" aria-label="Site"><a href="/">Live conditions</a> &middot; <a href="/radar.html">Radar</a> &middot; <a href="/water.html">Lake Havasu water level</a></nav>
+      <nav class="ftnav" aria-label="Site"><a href="/">Live conditions</a> &middot; <a href="/radar.html">Radar</a> &middot; <a href="/water.html">Lake Havasu water level</a> &middot; <a href="/rain.html">Rain &amp; storms</a></nav>
     </div>
   </main>
 


### PR DESCRIPTION
Refs #91 (closes with the key deploy). Hardware confirmed end-to-end: WH31L paired to the GW1100, gateway posting to our ingest — field names captured **empirically** from its payload (`lightning` km · `lightning_num` today · `lightning_time` epoch · `wh57batt`).

## What's in it
- **`lightning.js`** — pure helpers: the agreed **0–3 bolt level** (quiet / distant / in-the-area / close, from recency + proximity + rate over stored readings; midnight-reset-safe strike counting), km→mi, and `?mock=quiet|distant|close` scenarios so every level previews on a clear day.
- **`handler.js`** — lightning fields → `NUMERIC`; **per-station rain watermark** (bug fix: one shared watermark would let two posting stations corrupt each other's rain detection once the gateway key is allowed).
- **`read.js`** — `lightning` summary on `/api/current` (soft-fail) + new **`/api/lightning`** (`?hours=` series, `?mock=`).
- **Home rain card** — 0–3 **bolt meter** (flicker at level ≥2; `prefers-reduced-motion` safe) + "nearest ~X mi · N today · last M min ago" + **Storms →** link. Hidden until the detector reports.
- **NEW `/rain.html` "Rain & Storms"** — rain + bolts hero; **range-ring strike display** (distance-only — honest to a no-bearing sensor); strikes/hour + distance-trend chart (24h); rainfall totals + **dry streak**; 7-day rain chances; **sky-flash** animation (random while active, fires on a *real* counter increment, off under reduced motion). Full SEO head, sitemap, footer navs everywhere; SW **v41/r5**.
- Tests **85/85** (`lightning.test.mjs`).

## Preview
`/rain.html?mockLightning=close` (level 3 + flashes + rings), `?mockLightning=distant`, `?mockLightning=quiet`; home: `/?mockLightning=distant`.

## Ship sequence
1. **Merge this PR** → deploys code (site + ingest). Bolt meter stays hidden (no gateway data stored yet).
2. **Gated key deploy** (separate approval): manual `sam deploy` adding the gateway PASSKEY to `AllowedStationKeys` (existing keys read back from live per house rules) → gateway rows start storing → meter + page go live on real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHfTY9b4p18XoeNJPactfL